### PR TITLE
rfe: add cloud-init parameter to kubevirt_vmrs

### DIFF
--- a/tests/vmrs.yml
+++ b/tests/vmrs.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create a vmreplicaset
+- name: Create a VM ReplicaSet
   hosts: localhost
   connection: local
   vars:
@@ -13,3 +13,12 @@
        insecure: yes
        labels:
         myvm: big
+       cloudinit: |
+           #cloud-config
+           hostname: baldr
+           users:
+             - name: kubevirt
+               gecos: KubeVirt Project
+               sudo: ALL=(ALL) NOPASSWD:ALL
+               ssh_authorized_keys:
+                 - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+KMp1F4SrKitvgILf8Q2GQbcOslIg4sfqUOf+m832zwoS2Z2ndmpr/3F+NtLq56cTaEzK9IPBIkNLJfsPqRsToLBYZD+l4S5FfuZ2xwCxGBH+TVXApO+SiD6c84rmjOx47665iQvMHKL+n/5gVvSdYDuegNKnj4rRr/eHnG2yC4TVZl3oHI7TPOUJT+kKjSWP1UesWTZmmck39IaFSmorg31X7g9hJHwq9JEDQilcbnIyqDZKiH6Ju4GjOU8mqhazBFB4qu/QDDb25pDpPd2pQGBilGvm7gwJCVnyDk9YZQU7gYE734KLDf5tCKMmEQSjwFx2Tj9mfZveCIJkaj3T kubevirt


### PR DESCRIPTION
* Added cloudinit parameter to the DOC section.
* Added cloudinit parameter to module argument spec as non-required.
* Added base64 import required to encode cloud-init data.

Fixes #36 