### PR TITLE
feat: add module to start/stop an OVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 - Ansible >= 2.4.3.0
 - [KubeVirt Python SDK](https://github.com/kubevirt/client-python)
+- [Kubernetes Python client](https://github.com/kubernetes-client/python)
 - [KubeVirt](https://github.com/kubevirt/kubevirt)
 
 ## Installation and usage
@@ -25,7 +26,9 @@ $ git clone https://github.com/kubevirt/ansible-kubevirt-modules
 
 2. [Install KubeVirt Python SDK](https://github.com/kubevirt/client-python#installation--usage)
 
-3. Once installed, add it to a playbook:
+3. [Install Kubernetes Python client](https://github.com/kubernetes-client/python/#installation)
+
+4. Once installed, add it to a playbook:
 
 ```
 ---
@@ -44,6 +47,7 @@ Because the role is referenced, the `hello-underworld` role is able to make use 
 * [Virtual Machine](tests/raw_vm.yml)
 * [Offline Virtual Machine](tests/raw_ovm.yml)
 * [Virtual Machine ReplicaSet](tests/raw_vmrs.yml)
+* [Stop Offline Virtual Machine](tests/kubevirt_ovm_stopped.yml)
 * [Virtual Machine facts](tests/kubevirt_vm_facts.yml)
 * [Offline Virtual Machine facts](tests/kubevirt_ovm_facts.yml)
 * [Virtual Machine Replica Set facts](tests/kubevirt_vmrs_facts.yml)

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_ovm_status.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_ovm_status.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2018, KubeVirt Team <@kubevirt>
+# Apache License, Version 2.0
+# (see LICENSE or http://www.apache.org/licenses/LICENSE-2.0)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: kubevirt_ovm_status
+
+short_description: Manage KubeVirt Offline VM state
+
+version_added: "2.5"
+
+author: KubeVirt Team (@kubevirt)
+
+description:
+  - "Use Kubernets Python SDK to manage the state of KubeVirt Offline
+     VirtualMachines."
+
+options:
+    state:
+        description:
+            - "Set the Offline VirtualMachine to either (C(running)) or
+            (C(stopped))."
+        required: false
+        default: "running"
+        choices: ["running", "stopped"]
+        type: str
+    name:
+        description:
+            - Name of the Offline VirtualMachine.
+        required: true
+        type: str
+    namespace:
+        description:
+            - Namespace where the Offline VirtualMachine exists.
+        required: true
+        type: str
+    api_version:
+        description:
+            - KubeVirt API version to use.
+        required: false
+        type: str
+        default: v1alpha1
+    verify_ssl:
+        description:
+            - Whether to verify SSL certificate.
+        required: false
+        type: bool
+        default: yes
+
+requirements:
+  - python >= 2.7
+  - kubernetes python client >= 6.0.0
+'''
+
+EXAMPLES = '''
+- name: Set baldr OVM running
+  kubevirt_ovm_status:
+    state: running
+    name: baldr
+    namespace: vms
+'''
+
+RETURN = ''' # '''
+
+import kubernetes.client
+from ansible.module_utils.basic import AnsibleModule
+from kubernetes.client.rest import ApiException
+from kubernetes.config import kube_config
+
+
+def main():
+    ''' Entry point. '''
+
+    args = dict({
+        'state': dict({
+            'default': 'running',
+            'choices': list(['running', 'stopped']),
+            'type': 'str'
+        }),
+        'name': dict({'required': True, 'type': 'str'}),
+        'namespace': dict({'required': True, 'type': 'str'}),
+        'api_version': dict({
+            'required': False,
+            'default': 'v1alpha1',
+            'type': 'str'
+        }),
+        'verify_ssl': dict({
+            'required': False,
+            'default': 'yes',
+            'type': 'bool'
+        })
+    })
+
+    module = AnsibleModule(argument_spec=args)
+    kube_config.load_kube_config()
+    configuration = kubernetes.client.Configuration()
+
+    if not module.params.get('verify_ssl'):
+        configuration.verify_ssl = False
+
+    api_client = kubernetes.client.ApiClient(configuration=configuration)
+    api_instance = kubernetes.client.CustomObjectsApi(api_client=api_client)
+    group = 'kubevirt.io'
+    plural = 'offlinevirtualmachines'
+    version = module.params.get('api_version')
+    namespace = module.params.get('namespace')
+    name = module.params.get('name')
+    state = True if module.params.get('state') == 'running' else False
+    body = dict()
+    body['spec'] = dict({'running': state})
+
+    try:
+        exists = api_instance.get_namespaced_custom_object(
+            group, version, namespace, plural, name)
+        current_state = exists.get('spec').get('running')
+
+        if current_state == state:
+            module.exit_json(changed=False)
+
+        api_response = api_instance.patch_namespaced_custom_object(
+            group, version, namespace, plural, name, body)
+        module.exit_json(changed=True, meta=api_response)
+    except ApiException as exc:
+        module.fail_json(msg='Failed to manage requested object',
+                         error=exc.reason)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/kubevirt_ovm_stopped.yml
+++ b/tests/kubevirt_ovm_stopped.yml
@@ -1,0 +1,11 @@
+---
+- name: Stop baldr OVM in vms namespace
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
+  tasks:
+    - kubevirt_ovm_status:
+        state: stopped
+        name: baldr
+        namespace: vms

--- a/tests/units/modules/test_kubevirt_ovm_status.py
+++ b/tests/units/modules/test_kubevirt_ovm_status.py
@@ -1,0 +1,73 @@
+import json
+import sys
+import pytest
+
+from ansible.compat.tests.mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+
+# FIXME: paths/imports should be fixed before submitting a PR to Ansible
+sys.path.append('lib/ansible/modules/cloud/kubevirt')
+
+import kubevirt_ovm_status as mymodule
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught
+    by the test case"""
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+class TestKubeVirtOVMStatus(object):
+    @patch('kubernetes.client.ApiClient')
+    @patch('kubernetes.client.CustomObjectsApi.patch_namespaced_custom_object')
+    @patch('kubernetes.client.CustomObjectsApi.get_namespaced_custom_object')
+    def test_run_ovm_main(self,
+                          mock_crd_get,
+                          mock_crd_patch,
+                          mock_client,
+                          monkeypatch):
+
+        monkeypatch.setattr(mymodule.AnsibleModule, "exit_json", exit_json)
+        args = dict(name='baldr', namespace='vms', state='stopped')
+        set_module_args(args)
+
+        mock_client.return_value = dict()
+        mock_crd_get.return_value = dict(spec=dict(running=True))
+        mock_crd_patch.return_value = dict()
+        with pytest.raises(AnsibleExitJson) as result:
+            mymodule.main()
+        assert result.value[0]['changed']
+        mock_crd_patch.assert_called_once_with(
+            'kubevirt.io', 'v1alpha1', 'vms', 'offlinevirtualmachines',
+            'baldr', dict(spec=dict(running=False)))
+
+    @patch('kubernetes.client.ApiClient')
+    @patch('kubernetes.client.CustomObjectsApi.patch_namespaced_custom_object')
+    @patch('kubernetes.client.CustomObjectsApi.get_namespaced_custom_object')
+    def test_run_ovm_same_state(self,
+                                mock_crd_get,
+                                mock_crd_patch,
+                                mock_client,
+                                monkeypatch):
+
+        monkeypatch.setattr(mymodule.AnsibleModule, "exit_json", exit_json)
+        args = dict(name='baldr', namespace='vms', state='stopped')
+        set_module_args(args)
+
+        mock_client.return_value = dict()
+        mock_crd_get.return_value = dict(spec=dict(running=False))
+        with pytest.raises(AnsibleExitJson) as result:
+            mymodule.main()
+        assert not result.value[0]['changed']


### PR DESCRIPTION
* Rather basic, using name, namespace and state, sets the OVM running
attribute to either true or false.
* Add example playbook setting the baldr ovm to be stopped.

It uses Kubernetes Python client because of [this issue](https://github.com/kubevirt/client-python/issues/20) in KubeVirt python client, when clarified and/or fixed, the module should be modified to use KubeVirt's.