### PR TITLE
Add module documentation and return blocks.

### DIFF
--- a/lib/ansible/module_utils/k8svirt/facts.py
+++ b/lib/ansible/module_utils/k8svirt/facts.py
@@ -14,10 +14,11 @@ from kubevirt.rest import ApiException
 if hasattr(sys, '_called_from_test'):
     sys.path.append('lib/ansible/module_utils/k8svirt')
     from common import K8sVirtAnsibleModule
-    from helper import AUTH_ARG_SPEC, FACTS_ARG_SPEC, get_helper, to_snake
+    from helper import AUTH_ARG_SPEC, NAME_ARG_SPEC, FACTS_ARG_SPEC, \
+        get_helper, to_snake
 else:
     from ansible.module_utils.k8svirt.helper import get_helper, AUTH_ARG_SPEC,\
-        FACTS_ARG_SPEC, to_snake
+        NAME_ARG_SPEC, FACTS_ARG_SPEC, to_snake
     from ansible.module_utils.k8svirt.common import K8sVirtAnsibleModule
 
 
@@ -33,6 +34,7 @@ class KubeVirtFacts(K8sVirtAnsibleModule):
     def argspec(self):
         """ Merge the initial module arguments """
         argspec = copy.deepcopy(FACTS_ARG_SPEC)
+        argspec.update(copy.deepcopy(NAME_ARG_SPEC))
         argspec.update(copy.deepcopy(AUTH_ARG_SPEC))
         return argspec
 

--- a/lib/ansible/module_utils/k8svirt/helper.py
+++ b/lib/ansible/module_utils/k8svirt/helper.py
@@ -11,11 +11,7 @@ import kubevirt as sdk
 
 from kubevirt import V1DeleteOptions
 
-HELPER_CLASS = {
-    'virtual_machine': "VirtualMachineHelper"
-}
-
-FACTS_ARG_SPEC = {
+NAME_ARG_SPEC = {
     'name': {
         'type': 'str',
         'required': False
@@ -28,6 +24,15 @@ FACTS_ARG_SPEC = {
         'type': 'str',
         'required': False
     },
+    'api_version': {
+        'type': 'str',
+        'required': False,
+        'default': 'v1',
+        'aliases': ['api', 'version'],
+    }
+}
+
+FACTS_ARG_SPEC = {
     'label_selectors': {
         'type': 'list',
         'default': []
@@ -38,7 +43,17 @@ FACTS_ARG_SPEC = {
     }
 }
 
-COMMON_ARG_SPEC = {
+RESOURCE_ARG_SPEC = {
+    'resource_definition': {
+        'type': 'dict',
+        'aliases': ['definition', 'inline']
+    },
+    'src': {
+        'type': 'path',
+    }
+}
+
+STATE_ARG_SPEC = {
     'state': {
         'default': 'present',
         'choices': ['present', 'absent'],
@@ -46,47 +61,47 @@ COMMON_ARG_SPEC = {
     'force': {
         'type': 'bool',
         'default': False,
-    },
-    'resource_definition': {
-        'type': 'dict',
-        'aliases': ['definition', 'inline']
-    },
-    'src': {
-        'type': 'path',
-    },
-    'kind': {},
-    'name': {},
-    'namespace': {},
-    'api_version': {
-        'default': 'v1',
-        'aliases': ['api', 'version'],
-    },
+    }
 }
 
 AUTH_ARG_SPEC = {
     'kubeconfig': {
         'type': 'path',
+        'required': False
     },
     'context': {},
-    'host': {},
-    'api_key': {
-        'no_log': True,
+    'host': {
+        'type': 'str',
+        'required': False
     },
-    'username': {},
+    'api_key': {
+        'type': 'str',
+        'no_log': True
+    },
+    'username': {
+        'type': 'str',
+        'required': False
+    },
     'password': {
-        'no_log': True,
+        'type': 'str',
+        'no_log': True
     },
     'verify_ssl': {
         'type': 'bool',
+        'required': False,
+        'default': True
     },
     'ssl_ca_cert': {
         'type': 'path',
+        'required': False
     },
     'cert_file': {
         'type': 'path',
+        'required': False
     },
     'key_file': {
         'type': 'path',
+        'required': False
     },
 }
 

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_facts.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_facts.py
@@ -15,52 +15,116 @@ module: kubevirt_facts
 
 short_description: Retrieve facts about KubeVirt resources
 
+description:
+  - Retrieve facts about KubeVirt resources
+
 version_added: "2.5"
 
 author: KubeVirt Team (@kubevirt)
 
-description:
-  - Retrieve facts about KubeVirt resources
+options:
+    name:
+        description:
+            - Resource name for which facts will be gathered.
+        required: false
+    namespace:
+        description:
+            - Namespace where to look for resources.
+            - Required when I(name) is specified.
+        required: false
+    kind:
+        description:
+            - Resource type.
+            - Must match one of the KubeVirt non-list resource types.
+            - See U(https://kubevirt.io/api-reference/master/definitions.html).
+        required: true
+    api_version:
+        description:
+            - KubeVirt API version.
+        required: false
+        default: v1
+    label_selectors:
+        description:
+            - Selector to limit the list of returned objects by their labels.
+        required: false
+    field_selectors:
+        description:
+            - Selector to limit the list of returned objects by their fields.
+        required: false
+    kubeconfig:
+        description:
+            - "Path to an existing Kubernetes config file. If not provided,
+               and no other connection options are provided, the kubernetes
+               client will attempt to load the default configuration file
+               from C(~/.kube/config.json)."
+    context:
+        description:
+            - The name of a context found in the config file.
+    host:
+        description:
+            - Provide a URL for accessing the API.
+    api_key:
+        description:
+            - Token used to authenticate with the API.
+    username:
+        description:
+            - Provide a username for authenticating with the API.
+    password:
+        description:
+            - Provide a password for authenticating with the API.
+    verify_ssl:
+        description:
+            - Whether or not to verify the API server's SSL certificates.
+        default: true
+    ssl_ca_cert:
+        description:
+            - Path to a CA certificate used to authenticate with the API.
+    cert_file:
+        description:
+            - Path to a certificate used to authenticate with the API.
+    key_file:
+        description:
+            - Path to a key file used to authenticate with the API.
 
 requirements:
-  - python >= 2.7
-  - kubevirt-python >= v0.6.0-177-gd265c3c
+    - python >= 2.7
+    - kubevirt-python >= v0.6.0-177-gd265c3c
 '''
 
 EXAMPLES = '''
 - name: Facts for testvm in vms namespace
   kubevirt_facts:
-    name: testvm
-    namespace: vms
-    kind: VirtualMachine
+      name: testvm
+      namespace: vms
+      kind: VirtualMachine
   register: testvm_facts
 - debug:
-    var: testvm_facts
+      var: testvm_facts
 
 - name: Facts for all VMIs in the cluster
   kubevirt_facts:
-    kind: VirtualMachineInstance
+      kind: VirtualMachineInstance
   register: all_vmis
 - debug:
-    var: all_vmis
+      var: all_vmis
 
 - name: Facts for all VMIRS in vms namespace
   kubevirt_facts:
-    kind: VirtualMachineInstanceReplicaSet
-    namespace: vms
+      kind: VirtualMachineInstanceReplicaSet
+      namespace: vms
   register: all_vms_vmirs
 - debug:
-    var: all_vms_vmirs
+      var: all_vms_vmirs
 
 - name: Facts for all VMIS in vms namespace with label 'app = web'
   kubevirt_facts:
-    kind: VirtualMachineInstance
-    namespace: vms
-    label_selector:
-      - app = web
+      kind: VirtualMachineInstance
+      namespace: vms
+      label_selector:
+          - app = web
   register: all_vmis_app_web
 - debug:
-    var: all_vmis_app_web
+      var: all_vmis_app_web
 '''
 
 RETURN = '''
@@ -72,28 +136,28 @@ items:
   returned: On success.
   type: complex
   contains:
-    api_version:
-      description: The versioned schema of the object representation.
-      returned: success
-      type: str
-    kind:
-      description: The REST resource type this object represents.
-      returned: success
-      type: str
-    metadata:
-      description: "Metadata includes name, namespace, annotations,
-                    labels, etc."
-      returned: success
-      type: dict
-    spec:
-      description: "Specific attributes of the object depending
-                    on the I(api_version) and I(kind)."
-      returned: success
-      type: dict
-    status:
-      description: Current status details for the object.
-      returned: success
-      type: dict
+      api_version:
+          description: The versioned schema of the object representation.
+          returned: success
+          type: str
+      kind:
+          description: The REST resource type this object represents.
+          returned: success
+          type: str
+      metadata:
+          description: "Metadata includes name, namespace, annotations,
+                        labels, etc."
+          returned: success
+          type: dict
+      spec:
+          description: "Specific attributes of the object depending
+                        on the I(api_version) and I(kind)."
+          returned: success
+          type: dict
+      status:
+          description: Current status details for the object.
+          returned: success
+          type: dict
 '''
 
 from ansible.module_utils.k8svirt.facts import KubeVirtFacts

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_raw.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_raw.py
@@ -15,31 +15,182 @@ module: kubevirt_raw
 
 short_description: Manage KubeVirt objects
 
+description:
+    - Use KubeVirt Python SDK to perform CRUD operations on KubeVirt objects.
+    - Pass the object definition from a source file or inline.
+    - Authenticate using either a config file, certificates, password or token.
+
 version_added: "2.5"
 
 author: KubeVirt Team (@kubevirt)
 
-description:
-  - Use KubeVirt Python SDK to perform CRUD operations on KubeVirt objects.
-  - Pass the object definition from a source file or inline.
-  - Authenticate using either a config file, certificates, password or token.
-
-extends_documentation_fragment:
-
+options:
+    state:
+        description:
+            - "Define the resource state, wether created C(present)
+               or deleted C(absent)."
+        required: false
+        default: present
+        choices:
+            - present
+            - absent
+    force:
+        description:
+            - "When C(true) or C(yes), together with I(state=present),
+               the defined resource will be forcefully replaced."
+        required: false
+        default: false
+    name:
+        description:
+            - Resource name for which facts will be gathered.
+        required: false
+    namespace:
+        description:
+            - Namespace where to look for resources.
+            - Required when I(name) is specified.
+        required: false
+    kind:
+        description:
+            - Resource type.
+            - Must match one of the KubeVirt non-list resource types.
+            - See U(https://kubevirt.io/api-reference/master/definitions.html).
+        required: true
+    api_version:
+        description:
+            - KubeVirt API version.
+        required: false
+        default: v1
+    resource_definition:
+        description:
+            - Provide an inline valid YAML for KubeVirt resource.
+            - Required when I(state=present).
+            - Mutually exclusive with I(src).
+        required: false
+    src:
+        description:
+            - Provide a valid YAML definition, loading it from a file.
+            - Mutually exclusive with I(resource_definition).
+    kubeconfig:
+        description:
+            - "Path to an existing Kubernetes config file. If not provided,
+               and no other connection options are provided, the kubernetes
+               client will attempt to load the default configuration file
+               from C(~/.kube/config.json)."
+    context:
+        description:
+            - The name of a context found in the config file.
+    host:
+        description:
+            - Provide a URL for accessing the API.
+    api_key:
+        description:
+            - Token used to authenticate with the API.
+    username:
+        description:
+            - Provide a username for authenticating with the API.
+    password:
+        description:
+            - Provide a password for authenticating with the API.
+    verify_ssl:
+        description:
+            - Whether or not to verify the API server's SSL certificates.
+        default: true
+    ssl_ca_cert:
+        description:
+            - Path to a CA certificate used to authenticate with the API.
+    cert_file:
+        description:
+            - Path to a certificate used to authenticate with the API.
+    key_file:
+        description:
+            - Path to a key file used to authenticate with the API.
 
 requirements:
-  - python >= 2.7
-  - kubevirt-python >= 0.4.1-132-g074b4658
+    - python >= 2.7
+    - kubevirt-python >= 0.4.1-132-g074b4658
 '''
 
 EXAMPLES = '''
 - name: Create a VM from a source file
   kubevirt_raw:
-    state: present
-    src: /testing/vm.yml
+      state: present
+      src: /testing/vm.yml
+
+- name: Create VM defined inline
+  kubevirt_raw:
+      state: present
+      name: testvm
+      namespace: vms
+      verify_ssl: no
+      inline:
+          apiVersion: kubevirt.io/v1alpha2
+          kind: VirtualMachine
+          metadata:
+            name: testvm
+          spec:
+            running: false
+            selector:
+              matchLabels:
+                guest: testvm
+            template:
+              metadata:
+                labels:
+                  guest: testvm
+                  kubevirt.io/size: small
+              spec:
+                domain:
+                  resources:
+                    requests:
+                      memory: 64M
+                  devices:
+                    disks:
+                      - name: registrydisk
+                        volumeName: registryvolume
+                        disk:
+                          bus: virtio
+                      - name: cloudinitdisk
+                        volumeName: cloudinitvolume
+                        disk:
+                          bus: virtio
+                volumes:
+                  - name: registryvolume
+                    registryDisk:
+                      image: kubevirt/cirros-registry-disk-demo
+                  - name: cloudinitvolume
+                    cloudInitNoCloud:
+                      userDataBase64: SGkuXG4=
 '''
 
-RETURN = ''' # '''
+RETURN = '''
+result:
+    description:
+        - When creating or updating a resource. Otherwise empty.
+    returned: success
+    type: complex
+    contains:
+        api_version:
+            description: "Version of the schema being used for managing
+                          the defined resource."
+            returned: success
+            type: str
+        kind:
+            description: The resource type being managed.
+            returned: success
+            type: str
+        metadata:
+            description: Standard resource metadata, e.g. name, namespace, etc.
+            returned: success
+            type: complex
+        spec:
+            description: "Set of resource attributes, can vary based
+                          on the I(api_version) and I(kind)."
+            returned: success
+            type: complex
+        status:
+            description: Current status details for the resource.
+            returned: success
+            type: complex
+'''
 
 from ansible.module_utils.k8svirt.raw import KubeVirtRawModule
 

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_scale_vmirs.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_scale_vmirs.py
@@ -53,19 +53,48 @@ options:
         default: yes
 
 requirements:
-  - python >= 2.7
-  - kubernetes python client >= 6.0.0
+    - python >= 2.7
+    - kubernetes python client >= 6.0.0
 '''
 
 EXAMPLES = '''
 - name: Set freyja replicas to 2
   kubevirt_scale_vmirs:
-    name: baldr
-    namespace: vms
-    replicas: 2
+      name: baldr
+      namespace: vms
+      replicas: 2
 '''
 
-RETURN = ''' # '''
+RETURN = '''
+result:
+    description:
+        - When replica number is different, otherwise empty.
+    returned: success
+    type: complex
+    contains:
+        api_version:
+            description: "Version of the schema being used for scaling
+                          the defined resource."
+            returned: success
+            type: str
+        kind:
+            description: The resource type being scaled.
+            returned: success
+            type: str
+        metadata:
+            description: Standard resource metadata, e.g. name, namespace, etc.
+            returned: success
+            type: complex
+        spec:
+            description: "Set of resource attributes, can vary based
+                          on the I(api_version)."
+            returned: success
+            type: complex
+        status:
+            description: Current number of replicas.
+            returned: success
+            type: complex
+'''
 
 import kubernetes.client
 from ansible.module_utils.basic import AnsibleModule
@@ -119,7 +148,7 @@ def main():
 
         api_response = api_instance.patch_namespaced_custom_object(
             group, version, namespace, plural, name, body)
-        module.exit_json(changed=True, meta=api_response)
+        module.exit_json(changed=True, result=api_response)
     except ApiException as exc:
         module.fail_json(msg='Failed to manage requested object',
                          error=exc.reason)

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_vm_status.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_vm_status.py
@@ -15,12 +15,12 @@ module: kubevirt_vm_status
 
 short_description: Manage KubeVirt VM state
 
+description:
+    - Use Kubernets Python SDK to manage the state of KubeVirt VirtualMachines.
+
 version_added: "2.5"
 
 author: KubeVirt Team (@kubevirt)
-
-description:
-  - Use Kubernets Python SDK to manage the state of KubeVirt VirtualMachines.
 
 options:
     state:
@@ -28,7 +28,9 @@ options:
             - Set the VirtualMachine to either (C(running)) or (C(stopped)).
         required: false
         default: "running"
-        choices: ["running", "stopped"]
+        choices:
+            - running
+            - stopped
         type: str
     name:
         description:
@@ -54,19 +56,48 @@ options:
         default: yes
 
 requirements:
-  - python >= 2.7
-  - kubernetes python client >= 6.0.0
+    - python >= 2.7
+    - kubernetes python client >= 6.0.0
 '''
 
 EXAMPLES = '''
 - name: Set baldr VM running
   kubevirt_vm_status:
-    state: running
-    name: baldr
-    namespace: vms
+      state: running
+      name: baldr
+      namespace: vms
 '''
 
-RETURN = ''' # '''
+RETURN = '''
+result:
+    description:
+        - When replica number is different, otherwise empty.
+    returned: success
+    type: complex
+    contains:
+        api_version:
+            description: "Version of the schema being used for managing
+                          the defined resource."
+            returned: success
+            type: str
+        kind:
+            description: The resource type being managed.
+            returned: success
+            type: str
+        metadata:
+            description: Standard resource metadata, e.g. name, namespace, etc.
+            returned: success
+            type: complex
+        spec:
+            description: "Set of resource attributes, can vary based
+                          on the I(api_version)."
+            returned: success
+            type: complex
+        status:
+            description: Current status details for the resource.
+            returned: success
+            type: complex
+'''
 
 import kubernetes.client
 from ansible.module_utils.basic import AnsibleModule
@@ -125,7 +156,7 @@ def main():
 
         api_response = api_instance.patch_namespaced_custom_object(
             group, version, namespace, plural, name, body)
-        module.exit_json(changed=True, meta=api_response)
+        module.exit_json(changed=True, result=api_response)
     except ApiException as exc:
         module.fail_json(msg='Failed to manage requested object',
                          error=exc.reason)

--- a/tests/units/module_utils/k8svirt/test_k8svirt_raw.py
+++ b/tests/units/module_utils/k8svirt/test_k8svirt_raw.py
@@ -7,6 +7,7 @@ from ansible.compat.tests.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
+from kubevirt import V1VirtualMachineInstance
 
 # FIXME: paths/imports should be fixed before submitting a PR to Ansible
 sys.path.append('lib/ansible/module_utils/k8svirt')
@@ -36,12 +37,13 @@ class TestMyModule(object):
                                          mock_create,
                                          args_present):
         set_module_args(args_present)
-        mock_create.return_value = {}
+        mock_create.return_value = V1VirtualMachineInstance()
         mock_exists.return_value = None
         k = raw.KubeVirtRawModule()
         k.execute_module()
         mock_create.assert_called_once_with(None, 'vms')
-        mock_exit_json.assert_called_once_with(changed=True, result={})
+        mock_exit_json.assert_called_once_with(
+            changed=True, result=V1VirtualMachineInstance().to_dict())
 
     @patch('helper.VirtualMachineInstanceHelper.exists')
     @patch('raw.KubeVirtRawModule.exit_json')
@@ -66,11 +68,12 @@ class TestMyModule(object):
         args_present['force'] = 'yes'
         set_module_args(args_present)
         mock_exists.return_value = dict(name='testvm', namespace='vms')
-        mock_replace.return_value = dict()
+        mock_replace.return_value = V1VirtualMachineInstance()
         k = raw.KubeVirtRawModule()
         k.execute_module()
         mock_replace.assert_called_once_with(None, 'vms', 'testvm')
-        mock_exit_json.assert_called_once_with(changed=True, result={})
+        mock_exit_json.assert_called_once_with(
+            changed=True, result=V1VirtualMachineInstance().to_dict())
 
     @patch('helper.VirtualMachineInstanceHelper.delete')
     @patch('helper.VirtualMachineInstanceHelper.exists')


### PR DESCRIPTION
* Reorg arg_spec dicts to make them more flexible.
* Make sure `argspec` property uses the right dicts.
* Add documentation to facts module.
* Add documentation to `kubevirt_raw` module.
* Return block for `kubevirt_raw`.
* Return block for `kubevirt_scale_vmirs`.
* Return block for `kubevirt_vm_status`.

Fixes #70 