### PR TITLE
Add kind for task

### DIFF
--- a/tests/playbooks/kubevirt_vm_facts.yml
+++ b/tests/playbooks/kubevirt_vm_facts.yml
@@ -7,6 +7,7 @@
   tasks:
     - kubevirt_facts:
         name: baldr
+        kind: VirtualMachine
         namespace: vms
       register: baldr_facts
     - debug:


### PR DESCRIPTION
The 'kind' parameter is mandatory for the task to identify which entity is being queried.