### PR TITLE
Update requirements to use client-python release tag v0.1.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ pytest >= 3.6.0, < 4.0.0
 mock >= 2.0.0, < 3.0.0
 flake8 >= 3.5.0, < 4.0.0
 ansible>=2.4.0, < 3.0.0
-git+https://github.com/kubevirt/client-python.git@3e355bd1bd88570377fb91da1251a6a5e7d1ad34
+git+https://github.com/kubevirt/client-python.git@v0.1.0
 kubernetes >= 6.0.0, < 7.0.0


### PR DESCRIPTION
Update requirements to use client-python release tag v0.1.0
fixes: #85 

Signed-off-by: Vatsal Parekh <vatsalparekh@outlook.com>