### PR TITLE
Actually utilize KubeVirtVM class

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
@@ -250,7 +250,7 @@ class KubeVirtVM(KubernetesRawModule):
 
 def main():
     '''Entry point.'''
-    KubernetesRawModule().execute_module()
+    KubeVirtVM().execute_module()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The module was using the upstream k8s class by accident.