### PR TITLE
Use 'wait_timeout' instead of 'wait' arg

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
@@ -140,9 +140,9 @@ result:
                         till it completes.
            returned: success
            type: bool
-        timeout:
+        wait_timeout:
            description: Specifies how much time in seconds to wait for an
-                        action to compelte if 'wait' option is enabled.
+                        action to complete if 'wait' option is enabled.
            returned: success
            type: int
 '''

--- a/tests/playbooks/e2e.yaml
+++ b/tests/playbooks/e2e.yaml
@@ -13,7 +13,7 @@
         namespace: default
         name: "{{ pvc_name }}"
         wait: yes
-        timeout: 1000
+        wait_timeout: 1000
         inline:
           apiVersion: v1
           kind: PersistentVolumeClaim

--- a/tests/playbooks/kubevirt_raw_pvc.yml
+++ b/tests/playbooks/kubevirt_raw_pvc.yml
@@ -11,7 +11,7 @@
        namespace: default
        name: pvc-demo
        wait: yes
-       timeout: 1000
+       wait_timeout: 1000
        inline:
          apiVersion: v1
          kind: PersistentVolumeClaim


### PR DESCRIPTION
Commit 1: Bring back 'timeout' variable instead of 'wait_timeout'

Two options:
1. Switch to the new name – 'wait_timeout' – but then I need to modify existing playbooks to use the new var name.
2. Bring back the old var name, which is what this commit does.

I assume @machacekondra had a reason to switch to wait_timeout and it does sound cleaner. So, what do we do?