### PR TITLE
Handle 'merge_type' var as required

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
@@ -162,7 +162,8 @@ except ImportError as exc:
 
 RAW_ARG_SPEC = {
     'wait': {'type': 'bool', 'default': True},
-    'wait_timeout': {'type': 'int', 'default': 20}
+    'wait_timeout': {'type': 'int', 'default': 20},
+    'merge_type': {'type': 'list', 'choices': ['json', 'merge', 'strategic-merge']},
 }
 
 


### PR DESCRIPTION
For KubeVirtVM() to handle updating existing objects, merge_type must be properly handled. It wasn't before.