### PR TITLE
[WIP] Fix scaling wait code for current VMIRS behavior

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_scale_vmirs.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_scale_vmirs.py
@@ -217,20 +217,20 @@ class KubeVirtScaleVMIRS(KubernetesRawModule):
                 obj = ResourceInstance(resource, event['object'])
                 if obj.metadata.name == name and hasattr(obj, 'status'):
                     if replicas == 0:
-                        if not hasattr(obj.status, 'readyReplicas') or not obj.status.readyReplicas:
+                        if not hasattr(obj.status, 'replicas') or not obj.status.replicas:
                             return_obj = obj
                             watcher.stop()
                             break
-                    if hasattr(obj.status, 'readyReplicas') and obj.status.readyReplicas == replicas:
+                    if hasattr(obj.status, 'replicas') and obj.status.replicas == replicas:
                         return_obj = obj
                         watcher.stop()
                         break
 
         if not return_obj:
             self.fail_json(msg="Error fetching the patched object. Try a higher wait_timeout value.")
-        if replicas and return_obj.status.readyReplicas is None:
+        if replicas and return_obj.status.replicas is None:
             self.fail_json(msg="Failed to fetch the number of ready replicas. Try a higher wait_timeout value.")
-        if replicas and return_obj.status.readyReplicas != replicas:
+        if replicas and return_obj.status.replicas != replicas:
             self.fail_json(msg="Number of ready replicas is {0}. Failed to reach {1} ready replicas within "
                                "the wait_timeout period.".format(return_obj.status.ready_replicas, replicas))
         return return_obj.to_dict()

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt_raw.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt_raw.py
@@ -6,15 +6,13 @@ from ansible.compat.tests.mock import patch, MagicMock
 from ansible.module_utils.k8s.common import K8sAnsibleMixin
 from openshift.dynamic import Resource
 
-from utils import set_module_args, AnsibleExitJson, exit_json
+from utils import set_module_args, AnsibleExitJson, exit_json, RESOURCE_DEFAULT_ARGS
 
 # FIXME: paths/imports should be fixed before submitting a PR to Ansible
 sys.path.append('lib/ansible/modules/clustering/kubevirt')
 
 import kubevirt_raw as mymodule
 
-RESOURCE_DEFAULT_ARGS = { 'api_version': 'v1', 'group': 'kubevirt.io',
-                            'prefix': 'apis', 'namespaced': True }
 TESTABLE_KINDS = ( 'VirtualMachineInstance', 'VirtualMachine', 'VirtualMachineInstanceReplicaSet',
                     'VirtualMachineInstancePreset', 'PersistentVolumeClaim' )
  

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt_scale_vmirs.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt_scale_vmirs.py
@@ -1,11 +1,15 @@
 import sys
 import pytest
 
-from ansible.compat.tests.mock import patch
+from ansible.compat.tests.mock import patch, MagicMock
 
-from openshift.dynamic import ResourceContainer, ResourceInstance
+from ansible.module_utils.k8s.common import K8sAnsibleMixin
+from ansible.module_utils.k8s.raw import KubernetesRawModule
 
-from utils import set_module_args, AnsibleExitJson, exit_json
+from openshift.dynamic import Resource, ResourceInstance
+from openshift.helper.exceptions import KubernetesException
+
+from utils import set_module_args, AnsibleExitJson, exit_json, AnsibleFailJson, fail_json, RESOURCE_DEFAULT_ARGS
 
 # FIXME: paths/imports should be fixed before submitting a PR to Ansible
 sys.path.append('lib/ansible/modules/clustering/kubevirt')
@@ -13,41 +17,88 @@ sys.path.append('lib/ansible/modules/clustering/kubevirt')
 import kubevirt_scale_vmirs as mymodule
 
 
-
 class TestKubeVirtScaleVMIRSModule(object):
     @pytest.fixture(autouse=True)
     def setup_class(cls, monkeypatch):
         monkeypatch.setattr(
             mymodule.KubeVirtScaleVMIRS, "exit_json", exit_json)
-        args = dict(name='freyja', namespace='vms', replicas=2, wait=False)
+        monkeypatch.setattr(
+            mymodule.KubeVirtScaleVMIRS, "fail_json", fail_json)
+        # Create mock methods in Resource directly, otherwise dyn client
+        # tries binding those to corresponding methods in DynamicClient
+        # (with partial()), which is more problematic to intercept
+        Resource.get = MagicMock()
+        # Globally mock some methods, since all tests will use this
+        KubernetesRawModule.patch_resource = MagicMock()
+        KubernetesRawModule.patch_resource.return_value = ({}, None)
+        K8sAnsibleMixin.get_api_client = MagicMock()
+        K8sAnsibleMixin.get_api_client.return_value = None
+        K8sAnsibleMixin.find_resource = MagicMock()
+
+    @pytest.mark.parametrize("_replicas, _changed", ( (1, True),
+                                                      (2, False),
+                                                      (5, True), ) )
+    def test_scale_vmirs_nowait(self, _replicas, _changed):
+        _name = 'test-vmirs'
+        # Desired state:
+        args = dict(name=_name, namespace='vms', replicas=2, wait=False)
         set_module_args(args)
 
-    @patch('ansible.module_utils.k8s.common.K8sAnsibleMixin.get_api_client')
-    @patch('ansible.module_utils.k8s.raw.KubernetesRawModule.patch_resource')
-    @patch('ansible.module_utils.k8s.common.K8sAnsibleMixin.find_resource')
-    @patch('openshift.dynamic.ResourceContainer.get')
-    def test_scale_vmirs_main(
-        self, mock_get_resource, mock_find_resource, mock_patch_resource, mock_api_client,
-    ):
-        mock_api_client.return_value = None
-        mock_find_resource.return_value = ResourceContainer({})
-        mock_get_resource.return_value = ResourceInstance('', {'metadata': {'name': 'freyja'}, 'spec': {'replicas': 1}})
-        mock_patch_resource.return_value = ({}, None)
-        with pytest.raises(AnsibleExitJson) as result:
-            mymodule.KubeVirtScaleVMIRS().execute_module()
-        assert result.value[0]['changed']
+        # Mock pre-change state:
+        resource_args = dict( kind='VirtualMachineInstanceReplicaSet', **RESOURCE_DEFAULT_ARGS )
+        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        res_inst = ResourceInstance('', dict(metadata = {'name': _name}, spec = {'replicas': _replicas}))
+        Resource.get.return_value = res_inst
 
-    @patch('ansible.module_utils.k8s.common.K8sAnsibleMixin.get_api_client')
-    @patch('ansible.module_utils.k8s.raw.KubernetesRawModule.patch_resource')
-    @patch('ansible.module_utils.k8s.common.K8sAnsibleMixin.find_resource')
-    @patch('openshift.dynamic.ResourceContainer.get')
-    def test_scale_vmirs_same_replica_number(
-        self, mock_get_resource, mock_find_resource, mock_patch_resource, mock_api_client,
-    ):
-        mock_api_client.return_value = None
-        mock_find_resource.return_value = ResourceContainer({})
-        mock_get_resource.return_value = ResourceInstance('', {'metadata': {'name': 'freyja'}, 'spec': {'replicas': 2}})
-        mock_patch_resource.return_value = ({}, None)
+        # Actual test:
         with pytest.raises(AnsibleExitJson) as result:
             mymodule.KubeVirtScaleVMIRS().execute_module()
-        assert not result.value[0]['changed']
+        assert result.value[0]['changed'] == _changed
+
+
+    @pytest.mark.parametrize("_replicas, _changed", ( (1, True),
+                                                      (2, False),
+                                                      (5, True), ) )
+    @patch('kubevirt_scale_vmirs.KubeVirtScaleVMIRS._create_stream')
+    def test_scale_vmirs_wait(self, mock_create_stream, _replicas, _changed):
+        _name = 'test-vmirs'
+        # Desired state:
+        args = dict(name=_name, namespace='vms', replicas=_replicas, wait=True)
+        set_module_args(args)
+
+        # Mock pre-change state:
+        resource_args = dict( kind='VirtualMachineInstanceReplicaSet', **RESOURCE_DEFAULT_ARGS )
+        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        res_inst = ResourceInstance('', dict(metadata = {'name': _name}, spec = {'replicas': 2}))
+        Resource.get.return_value = res_inst
+
+        # Mock post-change state:
+        stream_obj = dict(
+            status = dict(replicas=_replicas),
+            metadata = dict(name = _name)
+            )
+        mock_watcher = MagicMock()
+        mock_create_stream.return_value = ( mock_watcher, [ dict(object=stream_obj) ] )
+
+        # Actual test:
+        with pytest.raises(AnsibleExitJson) as result:
+            mymodule.KubeVirtScaleVMIRS().execute_module()
+        assert result.value[0]['changed'] == _changed
+
+    @patch('openshift.watch.Watch')
+    def test_stream_creation(self, mock_watch):
+        _name = 'test-vmirs'
+        # Desired state:
+        args = dict(name=_name, namespace='vms', replicas=2, wait=True)
+        set_module_args(args)
+
+        # Mock pre-change state:
+        resource_args = dict( kind='VirtualMachineInstanceReplicaSet', **RESOURCE_DEFAULT_ARGS )
+        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        res_inst = ResourceInstance('', dict(metadata = {'name': _name}, spec = {'replicas': 3}))
+        Resource.get.return_value = res_inst
+
+        # Actual test:
+        mock_watch.side_effect = KubernetesException("Test", value=42)
+        with pytest.raises(AnsibleFailJson) as result:
+            mymodule.KubeVirtScaleVMIRS().execute_module()

--- a/tests/units/modules/clustering/kubevirt/utils.py
+++ b/tests/units/modules/clustering/kubevirt/utils.py
@@ -3,6 +3,8 @@ import json
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils import basic
 
+RESOURCE_DEFAULT_ARGS = { 'api_version': 'v1', 'group': 'kubevirt.io',
+                            'prefix': 'apis', 'namespaced': True }
 
 def set_module_args(args):
     args = json.dumps({'ANSIBLE_MODULE_ARGS': args})


### PR DESCRIPTION
This makes the scaling work.

This is regarding issue #116. Assuming upstream VMIRS behavior is correct, this code is mergable as–is. I've emailed kubevirt-dev and am waiting for clarification on this. If they say current behavior is fine, then this patch fixes the last bug I've stumbled upon.