### PR TITLE
Clean up VMIPreset sample playbooks

### DIFF
--- a/tests/playbooks/kubevirt_facts_vmipreset.yml
+++ b/tests/playbooks/kubevirt_facts_vmipreset.yml
@@ -1,10 +1,10 @@
 ---
-- name: Gather facts for vmips-small VirtualMachineInstancePreset in vms namespace
+- name: Gather facts for test-vmips-small VirtualMachineInstancePreset
   hosts: localhost
   connection: local
   tasks:
     - k8s_facts:
-        name: vmips-small
+        name: test-vmips-small
         namespace: default
         kind: VirtualMachineInstancePreset
       register: k8s_vmips

--- a/tests/playbooks/kubevirt_raw_remove.yml
+++ b/tests/playbooks/kubevirt_raw_remove.yml
@@ -17,5 +17,6 @@
       with_items:
         - { kind: VirtualMachine, name: test-fedora }
         - { kind: VirtualMachineInstance, name: test-fedora-vmi }
+        - { kind: VirtualMachineInstance, name: test-fedora-vmi-ps }
         - { kind: VirtualMachineInstanceReplicaSet, name: test-vmirs }
-        - { kind: VirtualMachineInstancePreset, name: test-vmps-small }
+        - { kind: VirtualMachineInstancePreset, name: test-vmips-small }

--- a/tests/playbooks/kubevirt_raw_vmi_from_preset.yml
+++ b/tests/playbooks/kubevirt_raw_vmi_from_preset.yml
@@ -3,22 +3,21 @@
   hosts: localhost
   connection: local
   tasks:
-    - name: Create test-fedora-vmi VMI
+    - name: Create test-fedora-vmi-ps VMI
       kubevirt_raw:
        state: present
-       name: test-fedora-vmi
+       name: test-fedora-vmi-ps
        namespace: default
        inline:
          apiVersion: kubevirt.io/v1alpha2
          kind: VirtualMachineInstance
          metadata:
-           name: test-fedora-vmi
+           name: test-fedora-vmi-ps
            namespace: default
+           labels:
+             kubevirt.io/vmPreset: vmi-small
          spec:
            domain:
-             resources:
-               requests:
-                 memory: 512M
              devices:
                disks:
                - volumeName: bootvolume
@@ -37,7 +36,7 @@
              cloudInitNoCloud:
                userData: |
                  #cloud-config
-                 hostname: test-fedora-vmi
+                 hostname: test-fedora-vmi-ps
                  users:
                    - name: kubevirt
                      gecos: KubeVirt Project

--- a/tests/playbooks/kubevirt_raw_vmipreset.yml
+++ b/tests/playbooks/kubevirt_raw_vmipreset.yml
@@ -5,25 +5,20 @@
   tasks:
     - kubevirt_raw:
        state: present
-       name: test-vmps-small
+       name: test-vmips-small
        namespace: default
        force: yes
        inline:
          apiVersion: kubevirt.io/v1alpha2
          kind: VirtualMachineInstancePreset
          metadata:
-           name: test-vmps-small
+           name: test-vmips-small
          spec:
            domain:
              resources:
                requests:
-                 memory: 1024M
-             devices:
-               disks:
-               - volumeName: myvolume
-                 name: mydisk
-                 disk:
-                   bus: virtio
+                 memory: 512M
+             devices: {}
            selector:
              matchLabels:
-               kubevirt.io/vmPreset: vmps-small
+               kubevirt.io/vmPreset: vmi-small


### PR DESCRIPTION
The idea is that kubevirt_raw_vmi.yml and kubevirt_raw_vmi_from_preset.yml create 1:1 same VMIs, they just do it slightly differently.