### PR TITLE
Improve merge dict so it works with nested dict

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
@@ -224,10 +224,18 @@ class KubeVirtVM(KubernetesRawModule):
     def __init__(self, *args, **kwargs):
         super(KubeVirtVM, self).__init__(*args, **kwargs)
 
-    def merge_dicts(self, x, y):
-        z = x.copy()
-        z.update(y)
-        return z
+    @staticmethod
+    def merge_dicts(x, y):
+        for k in set(x.keys()).union(y.keys()):
+            if k in x and k in y:
+                if isinstance(x[k], dict) and isinstance(y[k], dict):
+                    yield (k, dict(KubeVirtVM.merge_dicts(x[k], y[k])))
+                else:
+                    yield (k, y[k])
+            elif k in x:
+                yield (k, x[k])
+            else:
+                yield (k, y[k])
 
     @property
     def argspec(self):
@@ -343,7 +351,7 @@ class KubeVirtVM(KubernetesRawModule):
             template_spec['domain']['resources']['requests']['memory'] = memory
 
         if labels:
-            template['metadata']['labels'] = labels
+            definition['metadata']['labels'] = labels
 
         if machine_type:
             template_spec['domain']['machine']['type'] = machine_type
@@ -352,7 +360,7 @@ class KubeVirtVM(KubernetesRawModule):
             definition['spec']['running'] = state == 'running'
 
         # Perform create/absent action:
-        definition = self.merge_dicts(self.resource_definitions[0], definition)
+        definition = dict(self.merge_dicts(self.resource_definitions[0], definition))
 
         # TODO: Wait for running state in case of ephemeral VM.
         if ephemeral:

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt_vm.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt_vm.py
@@ -1,0 +1,28 @@
+import json
+import sys
+
+# FIXME: paths/imports should be fixed before submitting a PR to Ansible
+sys.path.append('lib/ansible/modules/clustering/kubevirt')
+
+import kubevirt_vm as mymodule
+
+
+class TestKubeVirtVmModule(object):
+
+    def test_simple_merge_dicts(self):
+        dict1 = {'labels': {'label1': 'value'}}
+        dict2 = {'labels': {'label2': 'value'}}
+        dict3 = json.dumps({'labels': {'label1': 'value', 'label2': 'value'}}, sort_keys=True)
+        assert dict3 == json.dumps(dict(mymodule.KubeVirtVM.merge_dicts(dict1, dict2)))
+
+    def test_simple_multi_merge_dicts(self):
+        dict1 = {'labels': {'label1': 'value', 'label3': 'value'}}
+        dict2 = {'labels': {'label2': 'value'}}
+        dict3 = json.dumps({'labels': {'label1': 'value', 'label2': 'value', 'label3': 'value'}}, sort_keys=True)
+        assert dict3 == json.dumps(dict(mymodule.KubeVirtVM.merge_dicts(dict1, dict2)))
+
+    def test_double_nested_merge_dicts(self):
+        dict1 = {'metadata': {'labels': {'label1': 'value', 'label3': 'value'}}}
+        dict2 = {'metadata': {'labels': {'label2': 'value'}}}
+        dict3 = json.dumps({'metadata': {'labels': {'label1': 'value', 'label2': 'value', 'label3': 'value'}}}, sort_keys=True)
+        assert dict3 == json.dumps(dict(mymodule.KubeVirtVM.merge_dicts(dict1, dict2)))


### PR DESCRIPTION
This patch fixes the `merge_dics` method. Previously it didn't work with nested dictionaries. For example merging dictinaries like:

```
dict1 = {
  'labels': {'label1': 'value'}
}
dict2 = {
  'labels': {'label2': 'value'}
}
```

Ended as `  'labels': {'label1': 'value'}` instead of `  'labels': {'label1': 'value', 'label2': 'value'}`.

This patch fixes it.
