### PR TITLE
kubvirt_vm: Add support for networks & interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ kubernetes
 **.pyc
 .coverage
 *venv/
+*.swp

--- a/tests/playbooks/kubevirt_vm_multus.yml
+++ b/tests/playbooks/kubevirt_vm_multus.yml
@@ -1,0 +1,65 @@
+- name: Create Fedora vm with two network interfaces
+  hosts: localhost
+  gather_facts: false
+  connection: local
+
+  # Before running this playbook you need to make sure you have created
+  # 'mynetconf' NetworkAttachmentDefinition. This is used by the second
+  # network intefaces of the VM. Below is one of the example of to create
+  # one. Also this example is using OpenVSwitch, so you need to make sure you
+  # have created br1 ovs bridge.
+  # More info: https://kubevirt.io/user-guide/#/workloads/virtual-machines/interfaces-and-networks?id=multus
+  #
+  #pre_tasks:
+  #  - name: Create NetworkAttachmentDefinition mynetconf
+  #    k8s:
+  #      apiVersion: "k8s.cni.cncf.io/v1"
+  #      kind: NetworkAttachmentDefinition
+  #      metadata:
+  #        name: mynetconf
+  #      spec:
+  #        config: '{
+  #            "cniVersion": "0.2.0",
+  #            "type": "ovs",
+  #            "bridge": "br1"
+  #          }'
+
+  tasks:
+    - name: Create Fedora vm with two network interfaces
+      kubevirt_vm:
+        state: present
+        name: myvm
+        namespace: default
+        memory: 1024M
+        labels:
+          app: galaxy
+          service: web
+          origin: vmware
+        interfaces:
+           - name: default
+             bridge: {}
+             network:
+               pod: {}
+           - name: mynet
+             bridge: {}
+             network:
+               multus:
+                 networkName: mynetconf
+        disks:
+          - name: registrydisk
+            volumeName: registryvolume
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            volumeName: cloudinitvolume
+            disk:
+              bus: virtio
+        volumes:
+          - name: registryvolume
+            registryDisk:
+              image: kubevirt/fedora-cloud-registry-disk-demo:latest
+          - name: cloudinitvolume
+            cloudInitNoCloud:
+              userData: |-
+                password: fedora
+                chpasswd: { expire: False }

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt_vm.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt_vm.py
@@ -1,13 +1,60 @@
 import json
+import pytest
 import sys
+
+from openshift.dynamic import Resource
+
+from ansible.compat.tests.mock import MagicMock
+from ansible.module_utils.k8s.common import K8sAnsibleMixin
+
+from utils import set_module_args, AnsibleExitJson, exit_json, fail_json, RESOURCE_DEFAULT_ARGS
 
 # FIXME: paths/imports should be fixed before submitting a PR to Ansible
 sys.path.append('lib/ansible/modules/clustering/kubevirt')
 
 import kubevirt_vm as mymodule
 
+KIND = 'VirtulMachine'
+
 
 class TestKubeVirtVmModule(object):
+
+    @pytest.fixture(autouse=True)
+    def setup_class(cls, monkeypatch):
+        monkeypatch.setattr(
+            mymodule.KubeVirtVM, "exit_json", exit_json)
+        monkeypatch.setattr(
+            mymodule.KubeVirtVM, "fail_json", fail_json)
+        # Create mock methods in Resource directly, otherwise dyn client
+        # tries binding those to corresponding methods in DynamicClient
+        # (with partial()), which is more problematic to intercept
+        Resource.get = MagicMock()
+        Resource.create = MagicMock()
+        Resource.delete = MagicMock()
+        # Globally mock some methods, since all tests will use this
+        K8sAnsibleMixin.get_api_client = MagicMock()
+        K8sAnsibleMixin.get_api_client.return_value = None
+        K8sAnsibleMixin.find_resource = MagicMock()
+
+    def test_vm_multus_creation(self):
+        args = dict(
+            state='present', name='testvm',
+            namespace='vms', api_version='v1',
+            interfaces=[
+                {'bridge': {}, 'name': 'default', 'network': {'pod': {}}},
+                {'bridge': {}, 'name': 'mynet', 'network': {'multus': {'networkName': 'mynet'}}},
+            ],
+        )
+        set_module_args(args)
+
+        Resource.get.return_value = None
+        resource_args = dict(kind=KIND, **RESOURCE_DEFAULT_ARGS)
+        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+
+        # Actual test:
+        with pytest.raises(AnsibleExitJson) as result:
+            mymodule.KubeVirtVM().execute_module()
+        assert result.value[0]['vm']['method'] == 'create' and result.value[0]['changed']
 
     def test_simple_merge_dicts(self):
         dict1 = {'labels': {'label1': 'value'}}


### PR DESCRIPTION
This PR propose structure to `interfaces` and `networks` parameters. I think the best solution would be to just pass it to kubevirt API again, but just flatten the structure. I was thinking even about doc, and again I propose just adding a link to official doc + some light doc of the parameter, and add example.