### PR TITLE
kubevirt_raw: correct exit_json for multiple results

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_raw.py
@@ -211,9 +211,7 @@ class KubeVirtVM(KubernetesRawModule):
 
         self.exit_json(**{
             'changed': changed,
-            'result': {
-                'results': results
-            }
+            'results': results
         })
 
     def _create_stream(self, resource, namespace, wait_time):


### PR DESCRIPTION
This: results[5].result.spec.running
is better than this: result.results[5].result.spec.running