### PR TITLE
Rename registryDisk to containerDisk

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_rs.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_rs.py
@@ -77,10 +77,11 @@ EXAMPLES = '''
         matchLabels:
             myvmi: myvmi
       disks:
-         - name: registrydisk
+         - name: containerdisk
            volume:
-             registryDisk:
-               image: kubevirt/cirros-registry-disk-demo:latest
+             containerDisk:
+               image: kubevirt/cirros-container-disk-demo:latest
+               path: /custom-disk/cirros.img
            disk:
              bus: virtio
 

--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
@@ -78,10 +78,11 @@ EXAMPLES = '''
       namespace: vms
       memory: 64M
       disks:
-        - name: registrydisk
+        - name: containerdisk
           volume:
-            registryDisk:
-              image: kubevirt/cirros-registry-disk-demo:latest
+            containerDisk:
+              image: kubevirt/cirros-container-disk-demo:latest
+              path: /custom-disk/cirros.img
           disk:
             bus: virtio
 
@@ -117,10 +118,11 @@ EXAMPLES = '''
       namespace: vms
       memory: 64M
       disks:
-        - name: registrydisk
+        - name: containerdisk
           volume:
-            registryDisk:
-              image: kubevirt/cirros-registry-disk-demo:latest
+            containerDisk:
+              image: kubevirt/cirros-container-disk-demo:latest
+              path: /custom-disk/cirros.img
           disk:
             bus: virtio
 
@@ -136,10 +138,11 @@ EXAMPLES = '''
       labels:
         kubevirt.io/vm: myvm
       disks:
-        - name: registrydisk
+        - name: containerdisk
           volume:
-            registryDisk:
-              image: kubevirt/cirros-registry-disk-demo:latest
+            containerDisk:
+              image: kubevirt/cirros-container-disk-demo:latest
+              path: /custom-disk/cirros.img
           disk:
             bus: virtio
 
@@ -155,10 +158,11 @@ EXAMPLES = '''
           password: fedora
           chpasswd: { expire: False }
       disks:
-        - name: registrydisk
+        - name: containerdisk
           volume:
-            registryDisk:
-              image: kubevirt/fedora-cloud-registry-disk-demo:latest
+            containerDisk:
+              image: kubevirt/fedora-cloud-container-disk-demo:latest
+              path: /disk/fedora.qcow2
           disk:
             bus: virtio
 

--- a/tests/playbooks/k8s_template.yml
+++ b/tests/playbooks/k8s_template.yml
@@ -39,7 +39,7 @@
                     disks:
                     - disk:
                         dev: vda
-                      name: registrydisk
+                      name: containerdisk
                       volumeName: registryvolume
                     - cdrom:
                         dev: vdb
@@ -47,8 +47,9 @@
                       volumeName: cloudinitvolume
                 volumes:
                 - name: registryvolume
-                  registryDisk:
-                    image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                  containerDisk:
+                    image: kubevirt/fedora-cloud-container-disk-demo:latest
+                    path: /disk/fedora.qcow2
                 - name: cloudinitvolume
                   cloudInitNoCloud:
                     userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==

--- a/tests/playbooks/k8s_vm.yml
+++ b/tests/playbooks/k8s_vm.yml
@@ -31,7 +31,7 @@
                    disks:
                    - disk:
                        bus: virtio
-                     name: registrydisk
+                     name: containerdisk
                      volumeName: registryvolume
                    - cdrom:
                        bus: virtio
@@ -39,8 +39,9 @@
                      volumeName: cloudinitvolume
                volumes:
                - name: registryvolume
-                 registryDisk:
-                   image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                 containerDisk:
+                   image: kubevirt/fedora-cloud-container-disk-demo:latest
+                   path: /disk/fedora.qcow2
                - name: cloudinitvolume
                  cloudInitNoCloud:
                    userData: |

--- a/tests/playbooks/k8s_vmi.yml
+++ b/tests/playbooks/k8s_vmi.yml
@@ -23,7 +23,7 @@
                disks:
                - disk:
                    bus: virtio
-                 name: registrydisk
+                 name: containerdisk
                  volumeName: registryvolume
                - cdrom:
                    bus: virtio
@@ -31,8 +31,9 @@
                  volumeName: cloudinitvolume
            volumes:
            - name: registryvolume
-             registryDisk:
-               image: kubevirt/fedora-cloud-registry-disk-demo:latest
+             containerDisk:
+               image: kubevirt/fedora-cloud-container-disk-demo:latest
+               path: /disk/fedora.qcow2
            - name: cloudinitvolume
              cloudInitNoCloud:
                userData: |

--- a/tests/playbooks/k8s_vmi_from_preset.yml
+++ b/tests/playbooks/k8s_vmi_from_preset.yml
@@ -22,7 +22,7 @@
                disks:
                - disk:
                    bus: virtio
-                 name: registrydisk
+                 name: containerdisk
                  volumeName: registryvolume
                - cdrom:
                    bus: virtio
@@ -30,8 +30,9 @@
                  volumeName: cloudinitvolume
            volumes:
            - name: registryvolume
-             registryDisk:
-               image: kubevirt/fedora-cloud-registry-disk-demo:latest
+             containerDisk:
+               image: kubevirt/fedora-cloud-container-disk-demo:latest
+               path: /disk/fedora.qcow2
            - name: cloudinitvolume
              cloudInitNoCloud:
                userData: |

--- a/tests/playbooks/k8s_vmirs.yml
+++ b/tests/playbooks/k8s_vmirs.yml
@@ -32,7 +32,7 @@
                    disks:
                    - disk:
                        bus: virtio
-                     name: registrydisk
+                     name: containerdisk
                      volumeName: registryvolume
                    - cdrom:
                        bus: virtio
@@ -40,8 +40,9 @@
                      volumeName: cloudinitvolume
                volumes:
                - name: registryvolume
-                 registryDisk:
-                   image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                 containerDisk:
+                   image: kubevirt/fedora-cloud-container-disk-demo:latest
+                   path: /disk/fedora.qcow2
                - name: cloudinitvolume
                  cloudInitNoCloud:
                    userData: |

--- a/tests/playbooks/kind_crud.yml
+++ b/tests/playbooks/kind_crud.yml
@@ -38,8 +38,9 @@
                         bus: virtio
                 volumes:
                 - name: myvolume
-                  registryDisk:
-                    image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                  containerDisk:
+                    image: kubevirt/fedora-cloud-container-disk-demo:latest
+                    path: /disk/fedora.qcow2
                 - cloudInitNoCloud:
                     userData: |
                       #cloud-config
@@ -105,8 +106,9 @@
                         bus: virtio
                 volumes:
                 - name: myvolume
-                  registryDisk:
-                    image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                  containerDisk:
+                    image: kubevirt/fedora-cloud-container-disk-demo:latest
+                    path: /disk/fedora.qcow2
                 - cloudInitNoCloud:
                     userData: |
                       #cloud-config
@@ -205,8 +207,9 @@
                         bus: virtio
                 volumes:
                 - name: myvolume
-                  registryDisk:
-                    image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                  containerDisk:
+                    image: kubevirt/fedora-cloud-container-disk-demo:latest
+                    path: /disk/fedora.qcow2
                 - cloudInitNoCloud:
                     userData: |
                       #cloud-config
@@ -305,8 +308,9 @@
                     bus: virtio
             volumes:
             - name: bootvolume
-              registryDisk:
-                image: kubevirt/fedora-cloud-registry-disk-demo:latest
+              containerDisk:
+                image: kubevirt/fedora-cloud-container-disk-demo:latest
+                path: /disk/fedora.qcow2
             - name: cloudinitvolume
               cloudInitNoCloud:
                 userData: |
@@ -534,8 +538,9 @@
                         bus: virtio
                 volumes:
                 - name: myvolume
-                  registryDisk:
-                    image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                  containerDisk:
+                    image: kubevirt/fedora-cloud-container-disk-demo:latest
+                    path: /disk/fedora.qcow2
                 - cloudInitNoCloud:
                     userData: |
                       #cloud-config
@@ -602,8 +607,9 @@
                         bus: virtio
                 volumes:
                 - name: myvolume
-                  registryDisk:
-                    image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                  containerDisk:
+                    image: kubevirt/fedora-cloud-container-disk-demo:latest
+                    path: /disk/fedora.qcow2
                 - cloudInitNoCloud:
                     userData: |
                       #cloud-config
@@ -676,8 +682,9 @@
                         bus: virtio
                 volumes:
                 - name: myvolume
-                  registryDisk:
-                    image: kubevirt/fedora-cloud-registry-disk-demo:latest
+                  containerDisk:
+                    image: kubevirt/fedora-cloud-container-disk-demo:latest
+                    path: /disk/fedora.qcow2
                 - cloudInitNoCloud:
                     userData: |
                       #cloud-config

--- a/tests/playbooks/kubevirt_vm_multus.yml
+++ b/tests/playbooks/kubevirt_vm_multus.yml
@@ -54,9 +54,10 @@
             password: fedora
             chpasswd: { expire: False }
         disks:
-          - name: registrydisk
+          - name: containerdisk
             volume:
-              registryDisk:
-                image: kubevirt/fedora-cloud-registry-disk-demo:latest
+              containerDisk:
+                image: kubevirt/fedora-cloud-container-disk-demo:latest
+                path: /disk/fedora.qcow2
             disk:
               bus: virtio


### PR DESCRIPTION
According to [[1]], [[2]], `registryDisk` has been renamed to `containerDisk`, which has also been merged into kubevirt master branch.  So this pull request is to be in line with the upstream change and includes the following changes:
1. Rename `registryDisk` to `containerDisk` in XML declarations and documentations
2. Rename `registerdisk` to `containerdisk` in `disk.name` XML definitions and documentations
3. Use the new image `kubevirt/cirros-container-disk-demo:latest` instead of `kubevirt/cirros-registry-disk-demo:latest` in XML definitions and documentations
4. Use the new image `kubevirt/fedora-cloud-container-disk-demo:latest` instead of `kubevirt/fedora-cloud-registry-disk-demo:latest` in XML definitions and documentations
5. Add new `path` support for `containerDisk` declaration in XML definitions and documentations, setting it to `/custom-disk/cirros.img` for image `cirros-container-disk-demo` (see [[3]]) and `/disk/fedora.qcow2` for image `fedora-cloud-container-disk-demo` (see [[4]])

[1]: https://github.com/kubevirt/kubevirt/pull/1730
[2]: https://groups.google.com/d/msgid/kubevirt-dev/CAMuConxp%2B3By5VRvvgRS7jcWWQBMHrTghaE_cBjG2-YGemZw5w%40mail.gmail.com?utm_medium=email&utm_source=footer
[3]: https://github.com/kubevirt/kubevirt/blob/master/images/cirros-container-disk-demo/Dockerfile
[4]: https://github.com/kubevirt/kubevirt/blob/master/images/fedora-cloud-container-disk-demo/Dockerfile 

Signed-off-by: imjoey <majunjiev@gmail.com>