### PR TITLE
playbooks: fix race in waiting-for-CDI tasks

### DIFF
--- a/tests/playbooks/e2e.yaml
+++ b/tests/playbooks/e2e.yaml
@@ -36,7 +36,7 @@
         kind: PersistentVolumeClaim
         api_version: v1
       register: pvc
-      until: "pvc.resources[0].status.phase == 'Bound' and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Succeeded'"
+      until: "pvc.resources[0].status.phase == 'Bound' and 'cdi.kubevirt.io/storage.pod.phase' in pvc.resources[0].metadata.annotations and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Succeeded'"
       delay: 10
       retries: 18
 

--- a/tests/playbooks/k8s_pvc.yml
+++ b/tests/playbooks/k8s_pvc.yml
@@ -32,6 +32,6 @@
         kind: PersistentVolumeClaim
         api_version: v1
       register: pvc
-      until: "pvc.resources[0].status.phase == 'Bound' and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Succeeded'"
+      until: "pvc.resources[0].status.phase == 'Bound' and 'cdi.kubevirt.io/storage.pod.phase' in pvc.resources[0].metadata.annotations and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Succeeded'"
       delay: 10
       retries: 18


### PR DESCRIPTION
CDI is not guaranteed to immediately annotate a PVC it detects. And if a
task assumes the annotation is there before it's there, the whole
playbook fails with an error like so:

"The conditional check 'pvc.resources[0].status.phase == 'Bound' and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Running'' failed. The error was: error while evaluating conditional (pvc.resources[0].status.phase == 'Bound' and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Running'): 'dict object' has no attribute 'cdi.kubevirt.io/storage.pod.phase'"

