### PR TITLE
Add api version detection logic

### DIFF
--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_preset.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_preset.py
@@ -97,14 +97,12 @@ if hasattr(sys, '_called_from_test'):
     from kubevirt import (
         virtdict,
         VM_COMMON_ARG_SPEC,
-        API_VERSION,
         KubeVirtRawModule,
     )
 else:
     from ansible.module_utils.kubevirt import (
         virtdict,
         VM_COMMON_ARG_SPEC,
-        API_VERSION,
         KubeVirtRawModule,
     )
 
@@ -154,7 +152,6 @@ class KubeVirtVMPreset(KubeVirtRawModule):
 def main():
     module = KubeVirtVMPreset()
     try:
-        module.api_version = API_VERSION
         module.execute_module()
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())

--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_rs.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_rs.py
@@ -118,14 +118,12 @@ if hasattr(sys, '_called_from_test'):
     from kubevirt import (
         virtdict,
         VM_COMMON_ARG_SPEC,
-        API_VERSION,
         KubeVirtRawModule,
     )
 else:
     from ansible.module_utils.kubevirt import (
         virtdict,
         VM_COMMON_ARG_SPEC,
-        API_VERSION,
         KubeVirtRawModule,
     )
 
@@ -179,7 +177,7 @@ class KubeVirtVMIRS(KubeVirtRawModule):
         wait_timeout = self.params.get('wait_timeout')
         replicas = self.params.get('replicas')
         name = self.name
-        resource = self.find_resource(KIND, self.api_version, fail=True)
+        resource = self.find_supported_resource(KIND)
 
         w, stream = self._create_stream(resource, namespace, wait_timeout)
         return self._read_stream(resource, w, stream, name, replicas)
@@ -218,7 +216,6 @@ class KubeVirtVMIRS(KubeVirtRawModule):
 def main():
     module = KubeVirtVMIRS()
     try:
-        module.api_version = API_VERSION
         module.execute_module()
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())

--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
@@ -201,7 +201,6 @@ if hasattr(sys, '_called_from_test'):
     from kubevirt import (
         virtdict,
         VM_COMMON_ARG_SPEC,
-        API_VERSION,
         KubeVirtRawModule,
     )
 else:
@@ -209,7 +208,6 @@ else:
         virtdict,
         KubeVirtRawModule,
         VM_COMMON_ARG_SPEC,
-        API_VERSION,
     )
 
 
@@ -241,7 +239,7 @@ class KubeVirtVM(KubeVirtRawModule):
         self.patch_resource(resource, definition, existing, self.name, self.namespace, merge_type='merge')
 
         if wait:
-            resource = self.find_resource('VirtualMachineInstance', self.api_version, fail=True)
+            resource = self.find_supported_resource('VirtualMachineInstance')
             w, stream = self._create_stream(resource, self.namespace, wait_timeout)
 
         if wait and stream is not None:
@@ -271,13 +269,13 @@ class KubeVirtVM(KubeVirtRawModule):
         wait_timeout = self.params.get('wait_timeout')
         resource_version = self.params.get('resource_version')
 
-        resource_vm = self.find_resource('VirtualMachine', self.api_version)
+        resource_vm = self.find_supported_resource('VirtualMachine')
         existing = self.get_resource(resource_vm)
         if resource_version and resource_version != existing.metadata.resourceVersion:
             return False
 
         existing_running = False
-        resource_vmi = self.find_resource('VirtualMachineInstance', self.api_version)
+        resource_vmi = self.find_supported_resource('VirtualMachineInstance')
         existing_running_vmi = self.get_resource(resource_vmi)
         if existing_running_vmi and hasattr(existing_running_vmi.status, 'phase'):
             existing_running = existing_running_vmi.status.phase == 'Running'
@@ -327,7 +325,6 @@ class KubeVirtVM(KubeVirtRawModule):
 def main():
     module = KubeVirtVM()
     try:
-        module.api_version = API_VERSION
         module.execute_module()
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt_preset.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt_preset.py
@@ -29,12 +29,13 @@ class TestKubeVirtVMIPresetModule(object):
         # tries binding those to corresponding methods in DynamicClient
         # (with partial()), which is more problematic to intercept
         Resource.get = MagicMock()
+        Resource.search = MagicMock()
         Resource.create = MagicMock()
         Resource.delete = MagicMock()
         # Globally mock some methods, since all tests will use this
         K8sAnsibleMixin.get_api_client = MagicMock()
         K8sAnsibleMixin.get_api_client.return_value = None
-        K8sAnsibleMixin.find_resource = MagicMock()
+        mymodule.KubeVirtVM.find_supported_resource = MagicMock()
 
     def test_preset_creation(self):
         args = dict(
@@ -45,8 +46,9 @@ class TestKubeVirtVMIPresetModule(object):
         set_module_args(args)
 
         Resource.get.return_value = None
+        Resource.search.return_value = None
         resource_args = dict(kind=KIND, **RESOURCE_DEFAULT_ARGS)
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVM.find_supported_resource.return_value = Resource(**resource_args)
 
         # Actual test:
         with pytest.raises(AnsibleExitJson) as result:
@@ -62,8 +64,9 @@ class TestKubeVirtVMIPresetModule(object):
         set_module_args(args)
 
         Resource.get.return_value = None
+        Resource.search.return_value = None
         resource_args = dict(kind=KIND, **RESOURCE_DEFAULT_ARGS)
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVM.find_supported_resource.return_value = Resource(**resource_args)
 
         # Actual test:
         with pytest.raises(AnsibleExitJson) as result:

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt_scale_rs.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt_scale_rs.py
@@ -28,12 +28,13 @@ class TestKubeVirtVMIRSModule(object):
         # tries binding those to corresponding methods in DynamicClient
         # (with partial()), which is more problematic to intercept
         Resource.get = MagicMock()
+        Resource.search = MagicMock()
         # Globally mock some methods, since all tests will use this
         KubernetesRawModule.patch_resource = MagicMock()
         KubernetesRawModule.patch_resource.return_value = ({}, None)
         K8sAnsibleMixin.get_api_client = MagicMock()
         K8sAnsibleMixin.get_api_client.return_value = None
-        K8sAnsibleMixin.find_resource = MagicMock()
+        mymodule.KubeVirtVMIRS.find_supported_resource = MagicMock()
 
     @pytest.mark.parametrize("_replicas, _changed", ( (1, True),
                                                       (3, True),
@@ -47,15 +48,15 @@ class TestKubeVirtVMIRSModule(object):
 
         # Mock pre-change state:
         resource_args = dict( kind='VirtualMachineInstanceReplicaSet', **RESOURCE_DEFAULT_ARGS )
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVMIRS.find_supported_resource.return_value = Resource(**resource_args)
         res_inst = ResourceInstance('', dict(metadata = {'name': _name}, spec = {'replicas': 2}))
         Resource.get.return_value = res_inst
+        Resource.search.return_value = [res_inst]
         KubernetesRawModule.patch_resource.return_value = dict(metadata = {'name': _name}, spec = {'replicas': _replicas}), None
 
         # Actual test:
         with pytest.raises(AnsibleExitJson) as result:
             mymodule.KubeVirtVMIRS().execute_module()
-        print result
         assert result.value[0]['changed'] == _changed
 
 
@@ -71,9 +72,10 @@ class TestKubeVirtVMIRSModule(object):
 
         # Mock pre-change state:
         resource_args = dict( kind='VirtualMachineInstanceReplicaSet', **RESOURCE_DEFAULT_ARGS )
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVMIRS.find_supported_resource.return_value = Resource(**resource_args)
         res_inst = ResourceInstance('', dict(metadata = {'name': _name}, spec = {'replicas': 2}))
         Resource.get.return_value = res_inst
+        Resource.search.return_value = [res_inst]
         KubernetesRawModule.patch_resource.return_value = dict(metadata = {'name': _name}, spec = {'replicas': _replicas}), None
 
         # Mock post-change state:
@@ -98,9 +100,10 @@ class TestKubeVirtVMIRSModule(object):
 
         # Mock pre-change state:
         resource_args = dict( kind='VirtualMachineInstanceReplicaSet', **RESOURCE_DEFAULT_ARGS )
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVMIRS.find_supported_resource.return_value = Resource(**resource_args)
         res_inst = ResourceInstance('', dict(metadata = {'name': _name}, spec = {'replicas': 3}))
         Resource.get.return_value = res_inst
+        Resource.search.return_value = [res_inst]
 
         # Actual test:
         mock_watch.side_effect = KubernetesException("Test", value=42)

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt_vm.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt_vm.py
@@ -31,12 +31,13 @@ class TestKubeVirtVmModule(object):
         # tries binding those to corresponding methods in DynamicClient
         # (with partial()), which is more problematic to intercept
         Resource.get = MagicMock()
+        Resource.search = MagicMock()
         Resource.create = MagicMock()
         Resource.delete = MagicMock()
         # Globally mock some methods, since all tests will use this
         K8sAnsibleMixin.get_api_client = MagicMock()
         K8sAnsibleMixin.get_api_client.return_value = None
-        K8sAnsibleMixin.find_resource = MagicMock()
+        mymodule.KubeVirtVM.find_supported_resource = MagicMock()
 
     def test_vm_multus_creation(self):
         args = dict(
@@ -50,8 +51,9 @@ class TestKubeVirtVmModule(object):
         set_module_args(args)
 
         Resource.get.return_value = None
+        Resource.search.return_value = None
         resource_args = dict(kind=KIND, **RESOURCE_DEFAULT_ARGS)
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVM.find_supported_resource.return_value = Resource(**resource_args)
 
         # Actual test:
         with pytest.raises(AnsibleExitJson) as result:
@@ -70,8 +72,9 @@ class TestKubeVirtVmModule(object):
         set_module_args(args)
 
         Resource.get.return_value = None
+        Resource.search.return_value = None
         resource_args = dict( kind=KIND, **RESOURCE_DEFAULT_ARGS )
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVM.find_supported_resource.return_value = Resource(**resource_args)
 
         # Actual test:
         with pytest.raises(AnsibleExitJson) as result:
@@ -89,8 +92,9 @@ class TestKubeVirtVmModule(object):
 
         # Mock pre-change state:
         Resource.get.return_value = None # Resource does NOT initially exist in cluster
+        Resource.search.return_value = None
         resource_args = dict( kind=KIND, **RESOURCE_DEFAULT_ARGS )
-        K8sAnsibleMixin.find_resource.return_value = Resource(**resource_args)
+        mymodule.KubeVirtVM.find_supported_resource.return_value = Resource(**resource_args)
 
         # Actual test:
         mock_watch.side_effect = KubernetesException("Test", value=42)


### PR DESCRIPTION
Use underlying library to dynamically discover supported api version for the k8s objects we operate on. Make sure to do something user–friendly in all possible cases, including "cluster too new to handle" and "cluster really old, but we can manage".

Fixes #77 