### PR TITLE
Add self.warnings to k8s–derived classes

### DIFF
--- a/lib/ansible/module_utils/kubevirt.py
+++ b/lib/ansible/module_utils/kubevirt.py
@@ -139,6 +139,7 @@ class KubeVirtRawModule(KubernetesRawModule):
     def execute_crud(self, kind, definition, template):
         """ Module execution """
         self.client = self.get_api_client()
+        self.warnings = []
 
         disks = self.params.get('disks', [])
         memory = self.params.get('memory')

--- a/lib/ansible/modules/clustering/kubevirt/k8s_service.py
+++ b/lib/ansible/modules/clustering/kubevirt/k8s_service.py
@@ -255,6 +255,7 @@ class KubernetesService(KubernetesRawModule):
     def execute_module(self):
         """ Module execution """
         self.client = self.get_api_client()
+        self.warnings = []
 
         api_version = 'v1'
         selector = self.params.get('selector')

--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_cdi_upload.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_cdi_upload.py
@@ -163,6 +163,7 @@ class KubeVirtCDIUpload(KubernetesRawModule):
         KIND = 'UploadTokenRequest'
 
         self.client = self.get_api_client()
+        self.warnings = []
 
         api_version = 'upload.cdi.kubevirt.io/{}'.format(API)
         pvc_name = self.params.get('pvc_name')

--- a/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
+++ b/lib/ansible/modules/clustering/kubevirt/kubevirt_vm.py
@@ -198,7 +198,6 @@ from openshift.dynamic.client import ResourceInstance
 import sys
 if hasattr(sys, '_called_from_test'):
     sys.path.append('lib/ansible/module_utils')
-    import kubevirt
     from kubevirt import (
         virtdict,
         VM_COMMON_ARG_SPEC,


### PR DESCRIPTION
KubernetesRawModule()–derived modules assume `self.warnings` exists when handling exceptions. This is true for the `k8s` module. It's not true for our modules. I will send a general fix for this to upstream, but for the time being we need this list created in our own code as well.

Without this if there's an exception ansible returns tens of lines of multi–level exception trace ending with something like `"msg": "'KubeVirtVM' object has no attribute 'warnings'"` and a user needs to parse all of it to figure out what the actual problem really is.

