### PR TITLE
Make api detection logic python2 compatible

### DIFF
--- a/lib/ansible/module_utils/kubevirt.py
+++ b/lib/ansible/module_utils/kubevirt.py
@@ -89,6 +89,10 @@ class KubeAPIVersion(Version):
         if myver > otherver:
             return 1
 
+    # python2 compatibility
+    def __cmp__(self, other):
+        return self._cmp(other)
+
 
 class KubeVirtRawModule(KubernetesRawModule):
     def __init__(self, *args, **kwargs):

--- a/tests/units/modules/clustering/kubevirt/test_kubevirt.py
+++ b/tests/units/modules/clustering/kubevirt/test_kubevirt.py
@@ -1,0 +1,34 @@
+import pytest
+
+from ansible.compat.tests.mock import patch, MagicMock
+#from units.compat.mock import patch, MagicMock
+
+# FIXME: paths/imports should be fixed before submitting a PR to Ansible
+import sys
+sys.path.append('lib/ansible/module_utils')
+
+from kubevirt import KubeAPIVersion
+
+@pytest.mark.parametrize("lval, operations, rval, result", [
+    ('v1', ['<', '<='], 'v2', True),
+    ('v1', ['>', '>=', '=='], 'v2', False),
+    ('v1', ['>'], 'v1alpha1', True),
+    ('v1', ['==', '<', '<='], 'v1alpha1', False),
+    ('v1beta5', ['==', '<=', '>='], 'v1beta5', True),
+    ('v1beta5', ['<', '>', '!='], 'v1beta5', False),
+
+])
+def test_kubeapiversion_comparisons(lval, operations, rval, result):
+    for op in operations:
+        test = '(KubeAPIVersion("{0}") {1} KubeAPIVersion("{2}")) == {3}'.format(lval, op, rval, result)
+        assert eval(test)
+
+
+@pytest.mark.parametrize("ver", ('nope', 'v1delta7', '1.5', 'v1beta', 'v'))
+def test_unsupported_versions(ver):
+    threw = False
+    try:
+        KubeAPIVersion(ver)
+    except ValueError:
+        threw = True
+    assert threw


### PR DESCRIPTION
Python3 vs. python2 incompatibilities made my last PR not work correctly on the latter. This should fix it.