### PR TITLE
Limit reqs to openshift client <0.9.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,4 @@ mock >= 2.0.0, < 3.0.0
 flake8 >= 3.5.0, < 4.0.0
 ansible >= 2.7.0, < 3.0.0
 # Openshift client installable by pip:
-openshift >= 0.8.2, < 1.0.0
+openshift >= 0.8.2, < 0.9.0


### PR DESCRIPTION
I've seen the changes in 0.9. Our code won't work with that version without some serious changes.