### PR TITLE
Revert "Update ansible.cfg"

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,2 +1,4 @@
 [defaults]
+library = ../lib/ansible/modules
+module_utils = ../lib/ansible/module_utils
 log_path = ../ansible.log


### PR DESCRIPTION
QE needs `ansible.cfg` to be the way it was until we actually merge the last module upstream and remove it from our repo. So a bit more time still.
