### PR TITLE
Update storageClassName to be used for QE env

### DIFF
--- a/tests/playbooks/e2e.yaml
+++ b/tests/playbooks/e2e.yaml
@@ -15,7 +15,6 @@
         access_modes:
         - ReadWriteOnce
         size: 100Mi
-        storage_class_name: standard
         cdi_source:
           http:
             url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"


### PR DESCRIPTION
This change makes e2e playbook work in both dev and QE env

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Correct storage class name
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
correction in storage class name
```
