### PR TITLE
Add network policy specification

### DIFF
--- a/roles/app_deployment/README.md
+++ b/roles/app_deployment/README.md
@@ -13,11 +13,12 @@ Requirements
 Role Variables
 --------------
 
-| Name                     | Default value |                                              |
-|--------------------------|---------------|-------------------------------------------------------------|
-| kubevirt_app_vms         | UNDEF         | Virtual machine applications specification. |
-| kubevirt_app_services    | UNDEF         | Services for the virtual machines and deployments. |
-| kubevirt_app_deployments | UNDEF         | Deployments applications specification/ |
+| Name                          | Default value |                                                    |
+|-------------------------------|---------------|----------------------------------------------------|
+| kubevirt_app_vms              | UNDEF         | Virtual machine applications specification.        |
+| kubevirt_app_services         | UNDEF         | Services for the virtual machines and deployments. |
+| kubevirt_app_deployments      | UNDEF         | Deployments applications specification.            |
+| kubevirt_app_network_policies | UNDEF         | By default, all vmis in a namespace are accessible from other vmis and network endpoints. To isolate one or more vmis in a project, you can create NetworkPolicy objects in that namespace to indicate the allowed incoming connections. Note that your networking solution must support NetworkPolicy. |
 
 `kubevirt_app_vms`
 | Name      | Default value |                                              |
@@ -26,6 +27,37 @@ Role Variables
 | affinity  | UNDEF         | Describes node affinity scheduling rules for the vm. |
 | node_affinity | UNDEF     | Describes vm affinity scheduling rules e.g. co-locate this vm in the same node, zone, etc. as some other vms |
 | anti_affinity | UNDEF     | Describes vm anti-affinity scheduling rules e.g. avoid putting this vm in the same node, zone, etc. as some other vms. |
+
+`kubevirt_app_network_policies`
+| Name                 | Default value |                                            |
+|----------------------|---------------|--------------------------------------------|
+| name                 | UNDEF         | Name of the network policy.                |
+| pod_selector         | UNDEF         | Dict of pod labels to which the policy apply. When empty selects all pods in policy's namespace. |
+| deny_all             | UNDEF         | If true deny all ingress and egress trafic to/from virtual machines. |
+| ingress              | UNDEF         | List of specific ingress rules for VMIs. |
+| ingress_allow_all    | UNDEF         | If true allow all ingress trafic to virtual machines. |
+| ingress_deny_all     | UNDEF         | If true all ingress trafic to virtual machines will be denied. |
+| ingress_allow_same_namespace | UNDEF | If true only ingress trafic from same namespace will be allowed. |
+| egress               | UNDEF         | List of specific egress rules for VMIs. |
+| egress_allow_all     | UNDEF         | If true allow all egress trafic to virtual machines. |
+| egress_deny_all      | UNDEF         | If true all egress trafic to virtual machines will be denied. |
+| egress_allow_same_namespace | UNDEF  | If true only egress trafic from same namespace will be allowed. |
+
+`ingress`
+| Name                 | Default value |                                            |
+|----------------------|---------------|--------------------------------------------|
+| ingress_ip_blocks    | UNDEF         | This selects particular IP CIDR ranges to allow as ingress sources. These should be cluster-external IPs, since VMI IPs are ephemeral and unpredictable |
+| ingress_namespace_selector | UNDEF   | This selects particular namespaces for which all Pods should be allowed as egress destinations. |
+| ingress_pod_selector | UNDEF         | Specify vmis to which the ingress rules apply. |
+| ingress_ports        | UNDEF         | Define ports and protocol of the ports to be allowed by ingress traffic. |
+
+`egress`
+| Name                 | Default value |                                            |
+|----------------------|---------------|--------------------------------------------|
+| egress_ip_blocks     | UNDEF         | This selects particular IP CIDR ranges to allow as ingress sources. These should be cluster-external IPs, since VMI IPs are ephemeral and unpredictable |
+| egress_namespace_selector | UNDEF    | This selects particular namespaces for which all Pods should be allowed as egress destinations. |
+| egress_pod_selector  | UNDEF         | Specify vmis to which the egress rules apply. |
+| egress_ports         | UNDEF         | Define ports and protocol of the ports to be allowed by egress traffic. |
 
 Dependencies
 ------------

--- a/roles/app_deployment/defaults/main.yml
+++ b/roles/app_deployment/defaults/main.yml
@@ -1,0 +1,4 @@
+kubevirt_app_vms: []
+kubevirt_app_deployments: []
+kubevirt_app_services: []
+kubevirt_app_network_policies: []

--- a/roles/app_deployment/examples/network_policy.yml
+++ b/roles/app_deployment/examples/network_policy.yml
@@ -1,0 +1,30 @@
+- name: Deploy application
+  hosts: localhost
+
+  vars:
+    kubevirt_app_vms:
+      - name: myhttp
+        namespace: default
+        memory: 1024Mi
+        image:
+          url: https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2
+          storage: 10Gi
+        labels:
+          app: myhttp
+
+    # Allow access to database pod from myhttp VM
+    kubevirt_app_network_policies:
+      - name: allow-db
+        namespace: default
+        pod_selector:
+          app: mydb
+        ingress:
+          - from:
+            - pod_selector:
+                app: myhttp
+            ports:
+              - protocol: TCP
+                port: 5432
+
+  roles:
+    - kubevirt.app_deployment

--- a/roles/app_deployment/tasks/main.yml
+++ b/roles/app_deployment/tasks/main.yml
@@ -13,3 +13,9 @@
     state: "{{ item.state | default(omit) }}"
     definition: "{{ lookup('template', 'templates/service.j2') }}"
   with_items: "{{ kubevirt_app_services }}"
+
+- name: Create network policies
+  k8s:
+    state: "{{ item.state | default(omit) }}"
+    definition: "{{ lookup('template', 'templates/network_policies.j2') }}"
+  with_items: "{{ kubevirt_app_network_policies }}"

--- a/roles/app_deployment/templates/network_policies.j2
+++ b/roles/app_deployment/templates/network_policies.j2
@@ -1,0 +1,104 @@
+#jinja2: lstrip_blocks: True
+kind: NetworkPolicy
+apiVersion: "{{ item.api_version | default('networking.k8s.io/v1') }}"
+metadata:
+  name: "{{ item.name | mandatory }}"
+  namespace: "{{ item.namespace | mandatory }}"
+spec:
+  podSelector:
+    matchLabels: {{ item.pod_selector | default({}) | to_yaml }}
+  {% if item.deny_all is defined %}
+  policyTypes:
+    - Ingress
+    - Egress
+  {% endif %}
+  {% if item.ingress_deny_all is defined and item.ingress_deny_all %}
+  policyTypes:
+    - Ingress
+  {% endif %}
+  {% if item.ingress_allow_all is defined and item.ingress_allow_all %}
+  ingress:
+    - {}
+  {% endif %}
+  {% if item.ingress_allow_same_namespace is defined and item.ingress_deny_all %}
+  ingress:
+    - from:
+      - podSelector: {}
+  {% endif %}
+  {% if item.ingress is defined %}
+  ingress:
+  {% for i in item.ingress %}
+      -
+      {% if i.from is defined %}
+        from:
+        {% for f in i.from %}
+        -
+        {% if f.ip_block is defined %}
+          ipBlock:
+            cidr: "{{ from.ip_block.cidr }}"
+            except: "{{ from.ip_block.except }}"
+        {% endif %}
+        {% if f.namespace_selector is defined %}
+          namespaceSelector:
+            matchLabels: {{ f.namespace_selector | to_yaml }}
+        {% endif %}
+        {% if f.pod_selector is defined %}
+          podSelector:
+            matchLabels: {{ f.pod_selector | to_yaml }}
+        {% endif %}
+        {% endfor %}
+        {% endif %}
+      {% if i.ports is defined %}
+        ports:
+        {% for port in i.ports %}
+          - protocol: "{{ port.protocol | default('TCP') }}"
+            port: {{ port.port | mandatory }}
+        {% endfor %}
+      {% endif %}
+  {% endfor %}
+  {% endif %}
+  {% if item.egress_deny_all is defined and item.egress_deny_all %}
+  policyTypes:
+    - Ingress
+  {% endif %}
+  {% if item.egress_allow_all is defined and item.egress_allow_all %}
+  egress:
+    - {}
+  {% endif %}
+  {% if item.egress_allow_same_namespace is defined and item.egress_deny_all %}
+  egress:
+    - from:
+      - podSelector: {}
+  {% endif %}
+  {% if item.egress is defined %}
+  egress:
+  {% for egress in item.egress %}
+      -
+      {% if egress.to is defined %}
+      to:
+      {% for to in egress.to %}
+        -
+        {% if to.ip_block is defined %}
+          ipBlock:
+            cidr: "{{ to.ip_block.cidr }}"
+            except: "{{ to.ip_block.except }}"
+        {% endif %}
+        {% if to.namespace_selector is defined %}
+          namespaceSelector:
+            matchLabels: {{ to.namespace_selector | to_yaml }}
+        {% endif %}
+        {% if to.pod_selector is defined %}
+          podSelector:
+            matchLabels: {{ to.pod_selector | to_yaml }}
+        {% endif %}
+        {% endfor %}
+        {% endif %}
+      {% if egress.ports is defined %}
+        ports:
+        {% for port in egress.ports %}
+          - protocol: "{{ port.protocol | default('TCP') }}"
+            port: {{ port.port | mandatory }}
+        {% endfor %}
+      {% endif %}
+  {% endfor %}
+  {% endif %}

--- a/tests/roles/deploy.yml
+++ b/tests/roles/deploy.yml
@@ -49,6 +49,19 @@
         labels:
           app: myapphttp
 
+    kubevirt_app_network_policies:
+      - name: allow-http
+        namespace: default
+        pod_selector:
+          app: myappdb
+        ingress:
+          - from:
+            - pod_selector:
+                app: myapphttp
+            ports:
+              - protocol: TCP
+                port: 5432
+
   roles:
     - app_deployment
 


### PR DESCRIPTION
Add new `kubevirt_app_network_policies` parameter to `app_deployment` role to manage Kubernetes `NetworkPolicy` object.