### PR TITLE
Dynamic test skipping based on issues status

### DIFF
--- a/tests/playbooks/all.yml
+++ b/tests/playbooks/all.yml
@@ -1,8 +1,6 @@
 - import_playbook: kubevirt_pvc.yml
-  when: ansible_version.full < "2.9.0"
 - import_playbook: kubevirt_vm.yml
 - import_playbook: kubevirt_dv_vm.yaml
 - import_playbook: kubevirt_preset.yml
 - import_playbook: kubevirt_vmir.yml
 - import_playbook: e2e.yaml
-  when: ansible_version.full < "2.9.0"

--- a/tests/playbooks/e2e.yaml
+++ b/tests/playbooks/e2e.yaml
@@ -10,6 +10,11 @@
     pvc_name: test-e2e-pvc
     service_name: test-e2e-service
   tasks:
+    - name: Check for known open issues
+      include_tasks: known_issues.yaml
+      vars:
+        current_playbook: e2e
+
     - name: Create PVC with CDI annotations
       kubevirt_pvc:
         state: present

--- a/tests/playbooks/known_issues.yaml
+++ b/tests/playbooks/known_issues.yaml
@@ -1,0 +1,28 @@
+- name: Set some global known_issues vars
+  set_fact:
+    skip_pvc: false
+    skip_vm: false
+    skip_dv_vm: false
+    skip_preset: false
+    skip_vmir: false
+    skip_e2e: false
+    current_playbook: ''
+
+    github_issues:
+    - name: pvc_module_242
+      url: https://api.github.com/repos/kubevirt/ansible-kubevirt-modules/issues/242
+
+- name: Fetch github issues
+  include_tasks: known_issues/github.yaml
+  with_items: "{{ github_issues }}"
+
+- name: "Known issue: ansible.git@devel breaks kubevirt_pvc #242"
+  set_fact:
+    skip_pvc: true
+    skip_e2e: true
+  when: (ansible_version.full == "2.8.1" or ansible_version.full == "2.8.2") and pvc_module_242.state == "open"
+
+- name: "Skipping this playbook due to open issues"
+  meta: end_play
+  when: "skip_{{ current_playbook }} == true"
+

--- a/tests/playbooks/known_issues/github.yaml
+++ b/tests/playbooks/known_issues/github.yaml
@@ -1,0 +1,9 @@
+- name: "Fetch {{ item.url }}"
+  uri:
+    url: "{{ item.url }}"
+  register: result
+  failed_when: not 'json' in result or not 'state' in result.json
+
+- name: "Set {{ item.name}} var"
+  set_fact:
+    "{{ item.name }}": "{{ result.json }}"

--- a/tests/playbooks/kubevirt_dv_vm.yaml
+++ b/tests/playbooks/kubevirt_dv_vm.yaml
@@ -6,6 +6,11 @@
     group/k8s:
       namespace: default
   tasks:
+    - name: Check for known open issues
+      include_tasks: known_issues.yaml
+      vars:
+        current_playbook: dv_vm
+
     - name: Create a Cirros VM from a DataVolume
       kubevirt_vm:
         state: running

--- a/tests/playbooks/kubevirt_preset.yml
+++ b/tests/playbooks/kubevirt_preset.yml
@@ -3,6 +3,11 @@
   connection: local
 
   tasks:
+    - name: Check for known open issues
+      include_tasks: known_issues.yaml
+      vars:
+        current_playbook: preset
+
     - name: Create mem preset
       kubevirt_preset:
         state: present

--- a/tests/playbooks/kubevirt_pvc.yml
+++ b/tests/playbooks/kubevirt_pvc.yml
@@ -3,6 +3,11 @@
   hosts: localhost
   connection: local
   tasks:
+    - name: Check for known open issues
+      include_tasks: known_issues.yaml
+      vars:
+        current_playbook: pvc
+
     - name: Create a PVC
       kubevirt_pvc:
         namespace: default

--- a/tests/playbooks/kubevirt_vm.yml
+++ b/tests/playbooks/kubevirt_vm.yml
@@ -6,6 +6,11 @@
     group/k8s:
       namespace: default
   tasks:
+    - name: Check for known open issues
+      include_tasks: known_issues.yaml
+      vars:
+        current_playbook: vm
+
     ############# EPHEMERAL ###############
 
     # For ephemerals `running` is an alias for `present`; also make sure it's actually Running

--- a/tests/playbooks/kubevirt_vmir.yml
+++ b/tests/playbooks/kubevirt_vmir.yml
@@ -3,6 +3,11 @@
   hosts: localhost
   connection: local
   tasks:
+    - name: Check for known open issues
+      include_tasks: known_issues.yaml
+      vars:
+        current_playbook: vmir
+
     - name: Create VMir
       kubevirt_rs:
         state: present


### PR DESCRIPTION
The case detection logic can't be done globally in an easy manner, since there's no variable sharing between playbooks. So it's run for each playbook with known potential issues. Seems to work.