### PR TITLE
Add topology_key to affinity tests and examples

### DIFF
--- a/roles/app_deployment/examples/deploy.yml
+++ b/roles/app_deployment/examples/deploy.yml
@@ -14,6 +14,7 @@
         affinity:
           soft:
             - weight: 1
+              topology_key: "kubernetes.io/hostname"
               term:
                 match_expressions:
                   - key: security

--- a/tests/roles/deploy.yml
+++ b/tests/roles/deploy.yml
@@ -14,6 +14,7 @@
         affinity:
           soft:
             - weight: 1
+              topology_key: "kubernetes.io/hostname"
               term:
                 match_expressions:
                   - key: security


### PR DESCRIPTION
This PR fixes the affinity tests of related to app_deployment role. `topology_key` is required, so it must be passed in tests as well.