### PR TITLE
stable-2.8 no longer has the pvc regression

### DIFF
--- a/tests/playbooks/known_issues.yaml
+++ b/tests/playbooks/known_issues.yaml
@@ -12,7 +12,7 @@
   set_fact:
     skip_pvc: true
     skip_e2e: true
-  when: ansible_version.full == "2.8.1" or ansible_version.full == "2.8.1.post0"
+  when: ansible_version.full == "2.8.1"
 
 - name: "Skipping this playbook due to open issues"
   meta: end_play


### PR DESCRIPTION
Only 2.8.1 has it, 2.8.2 won't.