### PR TITLE
Workaround for travis+minikube instability

### DIFF
--- a/tests/playbooks/known_issues.yaml
+++ b/tests/playbooks/known_issues.yaml
@@ -18,3 +18,8 @@
   meta: end_play
   when: "skip_{{ current_playbook }} == true"
 
+# This is a workaround for https://github.com/kubevirt/ansible-kubevirt-modules/issues/240
+- name: "Travis/minikube: give cluster time to recover from its instability"
+  pause:
+    seconds: 90
+  when: lookup('env','CI') == 'true' and lookup('env','TRAVIS') == 'true'

--- a/travis/print-debug-info.sh
+++ b/travis/print-debug-info.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+set -x
+
+kubectl get pods --all-namespaces
+
+free -m
+docker ps
+docker ps -q|xargs docker stats --no-stream
+
 kubectl get configmap -n kubevirt kubevirt-config -o yaml
 kubectl get pvc -o yaml
 kubectl get vmis -o yaml
 kubectl get vms -o yaml
-kubectl get pods --all-namespaces
 
+kubectl describe nodes
+
+minikube logs

--- a/travis/run-cluster.sh
+++ b/travis/run-cluster.sh
@@ -29,5 +29,7 @@ kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/$KUBEVIR
 
 sleep 12
 
+free -m
+kubectl get pods --all-namespaces
 kubectl describe nodes
 


### PR DESCRIPTION
What this does: sleep for 90 seconds before running a new playbook if env == travis. This gives minikube time to recover after whatever's wrong with it and then correctly run the next playbook.