### PR TITLE
Drop pvc cloning and obsolete known issues

### DIFF
--- a/tests/playbooks/known_issues.yaml
+++ b/tests/playbooks/known_issues.yaml
@@ -17,18 +17,6 @@
     skip_template: false
   when: lookup('env','KUBEVIRT_PROVIDER') is match('okd-.*') or lookup('env','KUBEVIRT_PROVIDER') is match('os-.*')
 
-- name: "Known issue: ansible.git@devel breaks kubevirt_pvc #242"
-  set_fact:
-    skip_pvc: true
-    skip_e2e: true
-  when: ansible_version.full == "2.8.1"
-
-# More info: https://github.com/kubevirt/ansible-kubevirt-modules/issues/265
-- name: "Known issue: openshift3 has issues with CDI"
-  set_fact:
-    skip_pvc: true
-  when: cluster_type == 'openshift' and openshift_version is match('3.*')
-
 - name: "Skipping this playbook due to open issues"
   meta: end_play
   when: "skip_{{ current_playbook }} == true"

--- a/tests/playbooks/kubevirt_pvc.yml
+++ b/tests/playbooks/kubevirt_pvc.yml
@@ -39,18 +39,11 @@
             url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
         wait: yes
 
-    - name: Clone the last pvc
-      kubevirt_pvc:
-        namespace: default
-        name: pvc-demo2
-        access_modes:
-        - ReadWriteOnce
-        size: 100Mi
-        cdi_source:
-          pvc:
-            namespace: default
-            name: pvc-demo
-        wait: yes
+    # Missing test: clone the last PVC
+    # This used to be possible with CDI, but with 1.9.4 cloning got limited to datavols
+    # only and won't be reintroduced for PVCs.
+    # However in k8s 1.15 spec.dataSource got introduced and it does the same thing. So once
+    # kubevirt_pvc gets support for that, there should again be a test for it here.
 
     - name: Remove all PVCs
       kubevirt_pvc:


### PR DESCRIPTION
Regarding pvc cloning – this used to be possible with CDI, but with 1.9.4 cloning got limited to datavols only and won't be reintroduced for PVCs. However in k8s 1.15 spec.dataSource got introduced and it does the same thing. So once kubevirt_pvc gets support for that, there should again be a test for it here.