### PR TITLE
Stop CI complaining about latest CDI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   global: # Make sure there are defaults for each matrix var
     - TEST=playbooks/all.yml
     - ANSIBLE_SOURCE=pip
+    - CDI_VER=v1.9.5
   matrix:
     - ANSIBLE_SOURCE=pip                  TEST=playbooks/all.yml
     - ANSIBLE_SOURCE=branch/stable-2.8    TEST=playbooks/all.yml

--- a/jenkins/cluster-sync.sh
+++ b/jenkins/cluster-sync.sh
@@ -2,11 +2,16 @@
 
 set -xe
 
+KUBEVIRT_VER=v0.19.0   # 0.19.x is the last kubevirt that supports openshift3
+CDI_VER=v1.9.5         # Won't pass on newer cdi (yet)
+
 cluster-up/oc.sh adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-operator
 cluster-up/oc.sh adm policy add-scc-to-group anyuid system:authenticated
 
-KUBEVIRT_VER=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-CDI_VER=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+LATEST_KUBEVIRT_VER=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+LATEST_CDI_VER=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+CDI_VER=${CDI_VER:-$LATEST_CDI_VER}
+KUBEVIRT_VER=${KUBEVIRT_VER:-$LATEST_KUBEVIRT_VER}
 cluster-up/oc.sh apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VER/cdi-operator.yaml
 cluster-up/oc.sh apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VER/cdi-operator-cr.yaml
 

--- a/travis/run-cluster.sh
+++ b/travis/run-cluster.sh
@@ -8,8 +8,10 @@ BASE_DIR=$(dirname $(realpath $0))
 
 bash -x $BASE_DIR/traviskube/start-cluster minikube
 
-KUBEVIRT_VER=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-CDI_VER=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+LATEST_KUBEVIRT_VER=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+LATEST_CDI_VER=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+CDI_VER=${CDI_VER:-$LATEST_CDI_VER}
+KUBEVIRT_VER=${KUBEVIRT_VER:-$LATEST_KUBEVIRT_VER}
 kubectl apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VER/cdi-operator.yaml
 kubectl apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VER/cdi-operator-cr.yaml
 


### PR DESCRIPTION
Force previous CDI version for the time being. I'll add support for latest version in a separate patch.