### PR TITLE
Travis: make sure required env vars are always being set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ cache:
 #   env: ANSIBLE_SOURCE=pr/9999
 # then ansible from ansible.git's PR 9999 will be installed and used for executing the playbook
 env:
-  global: # Make sure there are defaults for each matrix var
-    - TEST=playbooks/all.yml
-    - ANSIBLE_SOURCE=pip
-    - LATEST_KUBEVIRT_VER=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-    - LATEST_CDI_VER=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
   matrix:
     - ANSIBLE_SOURCE=pip                  TEST=playbooks/all.yml
     - ANSIBLE_SOURCE=branch/stable-2.8    TEST=playbooks/all.yml
@@ -44,9 +39,16 @@ install:
 # travis_terminate: ok=0, fail=1, error=2+
 # if minikube fails to start/deploy, that should be an error
 script:
+  # Make sure all required env vars have values:
+  - export LATEST_KUBEVIRT_VER=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+  - export LATEST_CDI_VER=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
   - export CDI_VER=${CDI_VER:-$LATEST_CDI_VER}
   - export KUBEVIRT_VER=${KUBEVIRT_VER:-$LATEST_KUBEVIRT_VER}
+  - export TEST=${TEST:-playbooks/all.yml}
+  - export ANSIBLE_SOURCE=${ANSIBLE_SOURCE:-pip}
+  # Make it easier to debug:
   - ansible-playbook --version
+  - export
   # Catch obvious errors before we spend the time on booting the cluster up:
   - ansible-playbook -vvv --syntax-check tests/$TEST || travis_terminate 1;
   # Error out if the cluster doesn't start. This can't be inside install:, because then running a


### PR DESCRIPTION
Custom builds override env:, so builds can't depend on vars defined there to be present… so move them to script:

AKA make it easy to trigger custom builds against upstream ansible PRs.