### PR TITLE
Add branch/stable-2.9 to CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   matrix:
     - ANSIBLE_SOURCE=pip                  TEST=playbooks/all.yml
     - ANSIBLE_SOURCE=branch/stable-2.8    TEST=playbooks/all.yml
+    - ANSIBLE_SOURCE=branch/stable-2.9    TEST=playbooks/all.yml
     - ANSIBLE_SOURCE=branch/devel         TEST=playbooks/all.yml
     - ANSIBLE_SOURCE=branch/devel         TEST=roles/all.yml
 

--- a/jenkins/tests.bats
+++ b/jenkins/tests.bats
@@ -26,6 +26,10 @@ run_test() {
   run_test branch/stable-2.8
 }
 
+@test "branch/stable-2.9" {
+  run_test branch/stable-2.9
+}
+
 @test "branch/devel" {
   run_test branch/devel
 }


### PR DESCRIPTION
This should've been added three weeks ago.