### PR TITLE
Fixed/reverted kubevirt playbooks by removing wait and changing image.

### DIFF
--- a/tests/playbooks/e2e.yaml
+++ b/tests/playbooks/e2e.yaml
@@ -21,18 +21,27 @@
         name: "{{ pvc_name }}"
         access_modes:
         - ReadWriteOnce
-        size: 100Mi
+        size: 5Gi
         cdi_source:
           http:
-            url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
-        wait: yes
+            url: "https://dl.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2"
+
+    - name: Wait for PVC to be ready
+      k8s_facts:
+        name: "{{ pvc_name }}"
+        kind: PersistentVolumeClaim
+        api_version: v1
+      register: pvc
+      until: "pvc.resources[0].status.phase == 'Bound' and 'cdi.kubevirt.io/storage.pod.phase' in pvc.resources[0].metadata.annotations and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Succeeded'"
+      delay: 15
+      retries: 30
 
     - name: Create a VM with the CDI PVC that was created
       kubevirt_vm:
         state: present
         name: "{{ vm_name }}"
         labels:
-          special: cirros-e2e-key
+          special: fedora-e2e-key
         memory: 64Mi
         cpu_cores: 1
         disks:
@@ -96,11 +105,11 @@
             targetPort: 22
             protocol: TCP
         selector:
-          special: cirros-e2e-key
+          special: fedora-e2e-key
         definition:
           metadata:
             labels:
-              kubevirt.io/vm: cirros-e2e-service
+              kubevirt.io/vm: fedora-e2e-service
           spec:
             externalTrafficPolicy: Cluster
 

--- a/tests/playbooks/kubevirt_dv_vm.yaml
+++ b/tests/playbooks/kubevirt_dv_vm.yaml
@@ -11,27 +11,30 @@
       vars:
         current_playbook: dv_vm
 
-    - name: Create a Cirros VM from a DataVolume
+    - name: Create a fedora VM from a DataVolume
       kubevirt_vm:
         state: running
-        name: cirros-dv
+        wait: true
+        wait_timeout: 200
+        name: fedora-dv-test
         labels:
           special: test-e2e-key
-        memory: 64Mi
+        memory: 2Gi
         cpu_cores: 1
         datavolumes:
-          - name: cirros-dv
+          - name: fedora-dv-test
             source:
               http:
-                url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+                url: "https://dl.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2"
             pvc:
+              storageClassName: "{{ storage_provisioner }}"
               accessModes:
                 - ReadWriteOnce
-              storage: 1Gi
+              storage: 5Gi
       register: result
       failed_when: result.changed != true or not result.method in ('create', 'apply')
 
     - name: Remove the VM recently created
       kubevirt_vm:
         state: absent
-        name: cirros-dv
+        name: fedora-dv-test

--- a/tests/playbooks/kubevirt_pvc.yml
+++ b/tests/playbooks/kubevirt_pvc.yml
@@ -12,6 +12,9 @@
       kubevirt_pvc:
         namespace: default
         name: pvc1
+        storage_class_name: "{{ storage_provisioner | default('standard') }}"
+        annotations:
+          "kubevirt.io/provisionOnNode" : "{{ node_name }}"
         access_modes:
         - ReadWriteOnce
         size: 100Mi
@@ -20,24 +23,50 @@
       kubevirt_pvc:
         namespace: default
         name: pvc-blank
+        storage_class_name: "{{ storage_provisioner | default('standard') }}"
+        annotations:
+          "kubevirt.io/provisionOnNode" : "{{ node_name }}"
         access_modes:
         - ReadWriteOnce
         size: 100Mi
         cdi_source:
           blank: yes
-        wait: yes
+
+    - name: Wait for blank PVC to be ready
+      k8s_facts:
+        name: pvc-blank
+        namespace: default
+        kind: PersistentVolumeClaim
+        api_version: v1
+      register: pvc
+      until: "pvc.resources[0].status.phase == 'Bound' and 'cdi.kubevirt.io/storage.pod.phase' in pvc.resources[0].metadata.annotations and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Succeeded'"
+      delay: 15
+      retries: 30
 
     - name: Create a PVC and fetch contents from an external http location
       kubevirt_pvc:
         namespace: default
         name: pvc-demo
+        storage_class_name: "{{ storage_provisioner | default('standard') }}"
+        annotations:
+          "kubevirt.io/provisionOnNode" : "{{ node_name }}"
         access_modes:
         - ReadWriteOnce
-        size: 100Mi
+        size: 5Gi
         cdi_source:
           http:
-            url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
-        wait: yes
+            url: "https://dl.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2"
+
+    - name: Wait for blank PVC to be ready
+      k8s_facts:
+        name: pvc-demo
+        namespace: default
+        kind: PersistentVolumeClaim
+        api_version: v1
+      register: pvc
+      until: "pvc.resources[0].status.phase == 'Bound' and 'cdi.kubevirt.io/storage.pod.phase' in pvc.resources[0].metadata.annotations and pvc.resources[0].metadata.annotations['cdi.kubevirt.io/storage.pod.phase'] == 'Succeeded'"
+      delay: 15
+      retries: 30
 
     # Missing test: clone the last PVC
     # This used to be possible with CDI, but with 1.9.4 cloning got limited to datavols
@@ -54,4 +83,3 @@
       - pvc1
       - pvc-blank
       - pvc-demo
-


### PR DESCRIPTION
Signed-off-by: Satyajit Bulage <sbulage@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- [x] Ansible module for kubevirt `kubevirt_pvc` is having issue with `wait` parameter.

- [x] Another playbooks required updated Fedora images than cirros image, due to `HTTP/1.1 403 Forbidden` issue.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```